### PR TITLE
fixed scroll page bug for issue drag on backlogs#show page

### DIFF
--- a/app/views/rb_master_backlogs/show.html.erb
+++ b/app/views/rb_master_backlogs/show.html.erb
@@ -28,7 +28,7 @@
 </h2>
 
 <div id="rb">
-  <div id="backlogs_container">
+  <div id="backlogs_container" class="clear">
     <div id="owner_backlogs_container">
       <%= render :partial => 'backlog', :collection => @owner_backlogs %>
     </div>

--- a/assets/javascripts/app/backlog.js
+++ b/assets/javascripts/app/backlog.js
@@ -26,14 +26,19 @@ RB.Backlog = (function ($) {
       // Make the list sortable
       this.getList().sortable({
         connectWith: '.stories',
-        placeholder: 'placeholder',
-        forcePlaceholderSize: true,
         dropOnEmpty: true,
         start:   this.dragStart,
         stop:    this.dragStop,
         update:  this.dragComplete,
         receive: this.dragChanged,
-        remove:  this.dragChanged
+        remove:  this.dragChanged,
+        containment: $('#backlogs_container'),
+        scroll: true,
+        helper: function(event, ui){
+          var $clone =  $(ui).clone();
+          $clone .css('position','absolute');
+          return $clone.get(0);
+        }
       });
 
       // Observe menu items

--- a/assets/stylesheets/master_backlog.css
+++ b/assets/stylesheets/master_backlog.css
@@ -310,3 +310,7 @@
 #rb #backlogs_container .stories .story.editing .story_points.editor {
   float: right;
 }
+
+.controller-rb_master_backlogs.action-show #main, 
+.controller-rb_master_backlogs.action-show #content, 
+.controller-rb_master_backlogs.action-show #rb #backlogs_container .backlog .stories {overflow: visible;}


### PR DESCRIPTION
- changed css attrib overflow to visible for some elements in the dom
- added clear to backlogs container that the height can be calculated even it only contains float elements
- added helper to jquery sortable for drag event, dragged element sticks to cursor
