### PR TITLE
enable the calendar widget in modal window

### DIFF
--- a/app/views/rb_master_backlogs/show.html.erb
+++ b/app/views/rb_master_backlogs/show.html.erb
@@ -42,3 +42,5 @@
     <div id="last_updated"><%= date_string_with_milliseconds(@last_update, 0.001) %></div>
   </div>
 </div>
+<% #include calendar js files in case they are needed for edit
+  include_calendar_headers_tags -%>

--- a/assets/stylesheets/master_backlog.css
+++ b/assets/stylesheets/master_backlog.css
@@ -314,3 +314,7 @@
 .controller-rb_master_backlogs.action-show #main, 
 .controller-rb_master_backlogs.action-show #content, 
 .controller-rb_master_backlogs.action-show #rb #backlogs_container .backlog .stories {overflow: visible;}
+
+.controller-rb_master_backlogs.action-show div.calendar {
+  z-index: 10000;
+}


### PR DESCRIPTION
- add calendar widget js for backlogs#show
- calendar is always on top via z-index
- it is now possible to use the calendar widget for custom fields from type date in the modal
