### PR TITLE
Fix jQuery selector for default background color of task dialogue.

### DIFF
--- a/app/assets/javascripts/backlogs/app/show_main.js
+++ b/app/assets/javascripts/backlogs/app/show_main.js
@@ -12,7 +12,7 @@ jQuery(function ($) {
   $('#assigned_to_id_options').change(function () {
     var selected = $(this).children(':selected');
     if (!defaultDialogColor) {
-      defaultDialogColor = $('<div id="rb"><div class="model issue task"></div></div>').children().css('background-color');
+      defaultDialogColor = $('#rb .task').css('background-color');
     }
     $(this).parents('.ui-dialog').css('background-color', selected.attr('color') || defaultDialogColor);
   });

--- a/app/assets/javascripts/backlogs/app/task.js
+++ b/app/assets/javascripts/backlogs/app/task.js
@@ -18,10 +18,11 @@ RB.Task = (function ($) {
       // Associate this object with the element for later retrieval
       this.$.data('this', this);
       this.$.find(".editable").live('click', this.handleClick);
+      this.defaultColor =  $('#rb .task').css('background-color');
     },
 
     beforeSave: function () {
-      var c = this.$.find('select.assigned_to_id').children(':selected').attr('color');
+      var c = this.$.find('select.assigned_to_id').children(':selected').attr('color') || this.defaultColor;
       this.$.css('background-color', c);
     },
 


### PR DESCRIPTION
- This will be color used in the edit window when 'assigned to' is set to a blank value.

Fixes Bug #408.
