### PR TITLE
Add numericality validator for 'remaining hours'.

### DIFF
--- a/lib/open_project/backlogs/patches/issue_patch.rb
+++ b/lib/open_project/backlogs/patches/issue_patch.rb
@@ -25,6 +25,11 @@ module OpenProject::Backlogs::Patches::IssuePatch
                                                :less_than                => 10_000,
                                                :if => lambda { |i| i.project && i.project.module_enabled?('backlogs') }
 
+      validates_numericality_of :remaining_hours, :only_integer => false,
+                                                  :allow_nil => true,
+                                                  :if => lambda { |i| i.project && i.project.module_enabled?('backlogs') }
+
+
       validates_each :parent_issue_id do |record, attr, value|
         validate_parent_issue_relation(record, attr, value)
 

--- a/lib/open_project/backlogs/patches/issue_patch.rb
+++ b/lib/open_project/backlogs/patches/issue_patch.rb
@@ -27,6 +27,7 @@ module OpenProject::Backlogs::Patches::IssuePatch
 
       validates_numericality_of :remaining_hours, :only_integer => false,
                                                   :allow_nil => true,
+                                                  :greater_than_or_equal_to => 0,
                                                   :if => lambda { |i| i.project && i.project.module_enabled?('backlogs') }
 
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -66,6 +66,37 @@ describe Issue do
         issue.should_not be_valid
       end
     end
+
+
+    describe 'remaining hours' do
+      it 'allows empty values' do
+        issue.remaining_hours.should be_nil
+        issue.should be_valid
+      end
+
+      it 'allows values greater than or equal to 0' do
+        issue.remaining_hours = '0'
+        issue.should be_valid
+
+        issue.remaining_hours = '1'
+        issue.should be_valid
+      end
+
+      it 'disallows negative values' do
+        issue.remaining_hours = '-1'
+        issue.should_not be_valid
+      end
+
+      it 'disallows string values, that are not numbers' do
+        issue.remaining_hours = 'abc'
+        issue.should_not be_valid
+      end
+
+      it 'allows non-integers' do
+        issue.remaining_hours = '1.3'
+        issue.should be_valid
+      end
+    end
   end
 
   describe 'definition of done' do


### PR DESCRIPTION
Fixes bug #409.

(and also adds validation for all other forms)
