### PR TITLE
fixes having a background color for a task in chrome when switching to nobody beeing assigned

### DIFF
--- a/app/assets/javascripts/backlogs/app/show_main.js
+++ b/app/assets/javascripts/backlogs/app/show_main.js
@@ -12,7 +12,8 @@ jQuery(function ($) {
   $('#assigned_to_id_options').change(function () {
     var selected = $(this).children(':selected');
     if (!defaultDialogColor) {
-      defaultDialogColor = $('#rb .task').css('background-color');
+      // fetch the color from the task rendered as a prototype/template for new tasks
+      defaultDialogColor = $('#issue_').css('background-color');
     }
     $(this).parents('.ui-dialog').css('background-color', selected.attr('color') || defaultDialogColor);
   });


### PR DESCRIPTION
Unfortunately it is currently impossible to cuke the color as css
attributes to my knowlage are not accessible by capybara.

Generally speaking, we should just assign css classes on user
switching and check for that. That would also clean up the code as such.
