### PR TITLE
removes ambiguity of plugin cucumber steps with core

### DIFF
--- a/features/edit_story.feature
+++ b/features/edit_story.feature
@@ -64,7 +64,7 @@ Feature: Edit story on backlogs view
   Scenario: Create a new story in the backlog
     Given I am on the master backlog
      When I open the "Product Backlog" menu
-      And I follow "New Story" within the "Product Backlog" menu
+      And I follow "New Story" of the "Product Backlog" menu
       And I close the "Product Backlog" menu
       And I fill in "Alice in Wonderland" for "subject"
       And I confirm the story form
@@ -76,7 +76,7 @@ Feature: Edit story on backlogs view
   Scenario: Create a new story in a sprint
     Given I am on the master backlog
      When I open the "Sprint 001" menu
-      And I follow "New Story" within the "Sprint 001" menu
+      And I follow "New Story" of the "Sprint 001" menu
       And I close the "Sprint 001" menu
       And I fill in "The Wizard of Oz" for "subject"
       And I fill in "3" for "story_points"
@@ -110,7 +110,7 @@ Feature: Edit story on backlogs view
   Scenario: Setting trackers of a story
     Given I am on the master backlog
      When I open the "Sprint 001" menu
-      And I follow "New Story" within the "Sprint 001" menu
+      And I follow "New Story" of the "Sprint 001" menu
       And I close the "Sprint 001" menu
       And I fill in "The Wizard of Oz" for "subject"
       And I select "Bug" from "tracker_id"
@@ -122,6 +122,6 @@ Feature: Edit story on backlogs view
   Scenario: Hiding trackers, that are not active in the project
     Given I am on the master backlog
      When I open the "Sprint 001" menu
-      And I follow "New Story" within the "Sprint 001" menu
+      And I follow "New Story" of the "Sprint 001" menu
       And I close the "Sprint 001" menu
      Then I should not see "Epic" within ".tracker_id.helper"

--- a/features/edit_story_tracker_and_status.feature
+++ b/features/edit_story_tracker_and_status.feature
@@ -56,29 +56,42 @@ Feature: Edit story tracker and status
         | old_status | new_status |
         | New        | Closed     |
     And I am already logged in as "romano"
+    And I am on the master backlog
 
   @javascript
   Scenario: Display only statuses which are allowed by workflow
-    Given I am on the master backlog
      When I click on the text "Story A"
-     Then "Closed" should be an option for "status_id" within ".editors"
-     And "Rejected" should not be an option for "status_id" within ".editors"
-     And I select "Closed" from "status_id"
+
+    And the available status of the story called "Story A" should be the following:
+        | New    |
+        | Closed |
+
+    When I select "Closed" from "status_id"
      And I confirm the story form
-     Then I should not see the status "New" for "Story A" within ".status_id.editable"
-     And I should see the status "Closed" for "Story A" within ".status_id.editable"
-     And "Rejected" should not be an option for "status_id" within ".editors"
+
+    Then the displayed attributes of the story called "Story A" should be the following:
+        | Status | Closed |
+
+    When I click on the text "Story A"
+
+    Then the available status of the story called "Story A" should be the following:
+        | Closed |
 
   @javascript
   Scenario: Select a status and change to a tracker that does not offer the status
-    Given I am on the master backlog
      When I click on the text "Story B"
-     Then "Rejected" should be an option for "status_id"
+
+     Then the available status of the story called "Story B" should be the following:
+        | New      |
+        | Rejected |
 
      When I select "Rejected" from "status_id"
       And I select "Bug" from "tracker_id"
-     Then the "status_id" field within ".editors" should contain ""
-      And "New" should be an option for "status_id"
+
+     Then the editable attributes of the story called "Story B" should be the following:
+        | Status | |
+     And the available status of the story called "Story B" should be the following:
+        | New    |
 
      When I confirm the story form
      Then the error alert should show "Status can't be blank"
@@ -87,13 +100,19 @@ Feature: Edit story tracker and status
       And I click on the text "Story B"
       And I select "New" from "status_id"
       And I confirm the story form
-     Then I should see the status "New" for "Story B" within ".status_id.editable"
+
+     Then the displayed attributes of the story called "Story B" should be the following:
+        | Status | New |
 
   @javascript
   Scenario: Edit a story having no permission for the status of the current ticket
-    Given I am on the master backlog
      When I click on the text "Story C"
-     Then "Resolved" should be an option for "status_id"
-     And "New" should be an option for "status_id"
+
+     Then the available status of the story called "Story C" should be the following:
+        | New      |
+        | Resolved |
+
      When I confirm the story form
-     Then I should see the status "Resolved" for "Story C" within ".status_id.editable"
+
+     Then the displayed attributes of the story called "Story C" should be the following:
+        | Status | Resolved |

--- a/features/edit_via_modal.feature
+++ b/features/edit_via_modal.feature
@@ -48,17 +48,10 @@ Feature: Edit issue via modal box
   @javascript
   Scenario: Edit issue via modal box
     When I go to the master backlog
-    And I follow "" within ".stories .story .id"
-
-    Then I should see "Story #"
-    And I should see "Story A"
-
-    When I follow "Update" within ".modal .contextual"
+    And I open the modal window for the story "Story A"
+    And I switch the modal window into edit mode
     And fill in "Story A changed" for "issue_subject"
     And I follow "Save"
-
-    Then I should see "Subject changed from Story A to Story A changed"
-
-    When I go to the master backlog
+    And I go to the master backlog
 
     Then I should see "Story A changed"

--- a/features/product_owner.feature
+++ b/features/product_owner.feature
@@ -77,7 +77,7 @@ Feature: Product Owner
       And I set the subject of the story to A Whole New Story
       And I create the story
      Then the 1st story in the "Product Backlog" should be "A Whole New Story"
-      And all positions should be unique within versions
+      And all positions should be unique for each version
 
   Scenario: Update a story
     Given I am on the master backlog

--- a/features/step_definitions/_then_steps.rb
+++ b/features/step_definitions/_then_steps.rb
@@ -113,7 +113,7 @@ Then /^the (\d+)(?:st|nd|rd|th) story in (?:the )?"(.+?)" should have the ID of 
   step %%I should see "#{actual_story.id}" within "#backlog_#{version.id} .story:nth-child(#{position}) .id div.t"%
 end
 
-Then /^all positions should be unique within versions$/ do
+Then /^all positions should be unique for each version$/ do
   Story.find_by_sql("select project_id, fixed_version_id, position, count(*) as dups from issues where not position is NULL group by project_id, fixed_version_id, position having count(*) > 1").length.should == 0
 end
 
@@ -241,23 +241,4 @@ end
 
 Then /^I should be notified that the issue "(.+?)" is an invalid parent to the issue "(.+?)" because of cross project limitations$/ do |parent_name, child_name|
   step %Q{I should see "#{I18n.t(:field_parent_issue)} is invalid because the issue '#{child_name}' is a backlogs task and as such can not have the backlogs story '#{parent_name}' as it´s parent as long as the story is in a different project" within "#errorExplanation"}
-end
-
-Then /^"([^"]*)" should( not)? be an option for "([^"]*)"(?: within "([^\"]*)")?$/ do |value, negate, field, selector|
-  scope = selector ? Nokogiri::CSS.xpath_for(selector).first : ""
-  unless negate
-    page.should have_xpath(scope  + "//select[@name='#{field}']/option[contains(.,'#{value}')]")
-  else
-    page.should_not have_xpath(scope  + "//select[@name='#{field}']/option[contains(.,'#{value}')]")
-  end
-end
-
-Then /^I should( not)? see the status "([^"]*)" for "([^"]*)" within "([^"]*)"$/ do |negate, value, story_name, selector|
-  story_id = Issue.find_by_subject(story_name).id
-  selector = "#story_#{story_id} " + selector
-  unless negate
-    step %Q{I should see "#{value}" within "#{selector}"}
-  else
-    step %Q{I should not see "#{value}" within "#{selector}"}
-  end
 end

--- a/features/step_definitions/_when_steps.rb
+++ b/features/step_definitions/_when_steps.rb
@@ -118,7 +118,7 @@ When /^I edit the sprint notes$/ do
   visit url_for(:controller => '/rb_wikis', :action => 'edit', :sprint_id => @sprint)
 end
 
-When /^I follow "(.+?)" within the "(.+?)" (?:backlogs )?menu$/ do |link, backlog_name|
+When /^I follow "(.+?)" of the "(.+?)" (?:backlogs )?menu$/ do |link, backlog_name|
   sprint = Sprint.find_by_name(backlog_name)
   step %Q{I follow "#{link}" within "#backlog_#{sprint.id} .menu"}
 end
@@ -137,7 +137,7 @@ When /^I click on the text "(.+?)"$/ do |locator|
   find(:xpath, %Q{//*[contains(text(), "#{locator}")]}).click
 end
 
-When /^I click on the element with class "(.+?)"$/ do |locator|
+When /^I click on the element with class "([^"]+?)"$/ do |locator|
   find(:css, ".#{locator}").click
 end
 

--- a/features/step_definitions/modal_steps.rb
+++ b/features/step_definitions/modal_steps.rb
@@ -1,0 +1,12 @@
+When(/^I open the modal window for the story "(.*?)"$/) do |subject|
+  story = Story.find_by_subject(subject)
+
+  within("#story_#{story.id}") do
+    click_link(story.id)
+  end
+end
+
+When(/^I switch the modal window into edit mode$/) do
+  click_link("Update")
+end
+

--- a/features/step_definitions/story_steps.rb
+++ b/features/step_definitions/story_steps.rb
@@ -1,0 +1,43 @@
+Then(/^the available status of the story called "(.+?)" should be the following:$/) do |story_name, table|
+  # the order of the available status is important
+  story = Story.find_by_subject(story_name)
+
+  expected = table.raw.flatten.join(" ")
+
+  within("#story_#{story.id} .editors") do
+    should have_field("status_id", :text => expected)
+  end
+end
+
+
+Then(/^the displayed attributes of the story called "(.+?)" should be the following:$/) do |story_name, table|
+  story = Story.find_by_subject(story_name)
+
+  within("#story_#{story.id}") do
+    table.rows_hash.each do |key, value|
+      case key
+      when "Status"
+        within(".status_id") do
+          should have_selector("div.t", :text => value)
+        end
+      else
+        raise "Not an implemented attribute"
+      end
+    end
+  end
+end
+
+Then(/^the editable attributes of the story called "(.+?)" should be the following:$/) do |story_name, table|
+  story = Story.find_by_subject(story_name)
+
+  within("#story_#{story.id} .editors") do
+    table.rows_hash.each do |key, value|
+      case key
+      when "Status"
+        should have_select("status_id", :text => value)
+      else
+        raise "Not an implemented attribute"
+      end
+    end
+  end
+end

--- a/features/step_definitions/version_steps.rb
+++ b/features/step_definitions/version_steps.rb
@@ -1,0 +1,13 @@
+Then(/^the editable attributes of the version should be the following:$/) do |table|
+  table.rows_hash.each do |key, value|
+    case key
+    when "Column in backlog"
+      page.should have_select(key, :selected => value)
+    when "Start date"
+      page.should have_field(key, :with => value)
+    else
+      raise "Not an implemented attribute"
+    end
+  end
+end
+

--- a/features/team_member.feature
+++ b/features/team_member.feature
@@ -77,7 +77,7 @@ Feature: Team Member
   Scenario: View the burndown chart from the backlogs dashboard
     Given I am on the master backlog
       And I open the "Sprint 002" backlogs menu
-     When I follow "Burndown Chart" within the "Sprint 002" menu
+     When I follow "Burndown Chart" of the "Sprint 002" menu
      Then I should see the burndown chart for sprint "Sprint 002"
 
   @javascript
@@ -89,7 +89,7 @@ Feature: Team Member
   #from appearing when they do
     Given I am on the master backlog
       And I open the "Sprint 002" backlogs menu
-      And I follow "Stories/Tasks" within the "Sprint 002" menu
+      And I follow "Stories/Tasks" of the "Sprint 002" menu
      Then I should see "Burndown Chart" within "#sidebar"
      When I follow "Burndown Chart" within "#sidebar"
      Then I should see the burndown chart for sprint "Sprint 002"

--- a/features/version_settings.feature
+++ b/features/version_settings.feature
@@ -37,10 +37,13 @@ Feature: Version Settings
 
   Scenario: One can select whether versions are displayed left or right (left is default) in the backlogs page
     When I go to the edit page of the version called "Sprint 001"
-    Then there should be a "version[version_settings_attributes][][display]" field within "#content form"
-    And the "version[version_settings_attributes][][display]" field within "#content form" should contain "2"
-    When I select "right" from "version[version_settings_attributes][][display]"
+
+    Then the editable attributes of the version should be the following:
+      | Column in backlog | left |
+
+    When I select "right" from "Column in backlog"
     And I press "Save"
+
     Then I should be on the settings/versions page of the project called "ecookbook"
 
   Scenario: Inherited versions can also be configured to be displayed left, right or not at all
@@ -53,39 +56,57 @@ Feature: Version Settings
         | name       | start_date | effective_date | sharing       |
         | shared     | 2010-01-01        | 2010-01-31     | system        |
     And I am working in project "ecookbook"
+
     When I go to the settings/versions page of the project called "ecookbook"
+
     Then I should see "Edit" within ".version.shared .buttons"
+
     When I follow "Edit" within ".version.shared .buttons"
-    Then there should be a "version[version_settings_attributes][][display]" field within "#content form"
-    And the "version[version_settings_attributes][][display]" field within "#content form" should contain "2"
-    When I select "right" from "version[version_settings_attributes][][display]"
+
+    Then the editable attributes of the version should be the following:
+      | Column in backlog | left |
+
+    When I select "right" from "Column in backlog"
     And I press "Save"
+
     Then I should be on the settings/versions page of the project called "ecookbook"
 
-  Scenario: Switch from right to left
+  Scenario: Setting "Column in backlog" to the different settings
     When I go to the edit page of the version called "Sprint 001"
-    And I select "right" from "version[version_settings_attributes][][display]"
+    And I select "right" from "Column in backlog"
     And I press "Save"
     And I go to the edit page of the version called "Sprint 001"
-    Then the "version[version_settings_attributes][][display]" field within "#content form" should contain "3"
+
+    Then the editable attributes of the version should be the following:
+      | Column in backlog | right |
+
     When I go to the edit page of the version called "Sprint 002"
-    When I select "left" from "version[version_settings_attributes][][display]"
+    And I select "left" from "Column in backlog"
     And I press "Save"
     And I go to the edit page of the version called "Sprint 002"
-    Then the "version[version_settings_attributes][][display]" field within "#content form" should contain "2"
+
+    Then the editable attributes of the version should be the following:
+      | Column in backlog | left |
+
     When I go to the edit page of the version called "Sprint 003"
-    When I select "right" from "version[version_settings_attributes][][display]"
+    And I select "none" from "Column in backlog"
     And I press "Save"
     And I go to the edit page of the version called "Sprint 003"
-    Then the "version[version_settings_attributes][][display]" field within "#content form" should contain "3"
+
+    Then the editable attributes of the version should be the following:
+      | Column in backlog | none |
+
     When I go to the master backlog of the project "ecookbook"
+
     Then I should see "Sprint 001" within "#owner_backlogs_container"
     And I should see "Sprint 002" within "#sprint_backlogs_container"
-    And I should see "Sprint 003" within "#owner_backlogs_container"
+    And I should not see "Sprint 003" within "#owner_backlogs_container"
+    And I should not see "Sprint 003" within "#sprint_backlogs_container"
 
   Scenario: There should be a version start date field
     When I go to the edit page of the version called "Sprint 001"
-    Then there should be a "version_start_date" field within "#content form"
+    Then the editable attributes of the version should be the following:
+      | Start date | 2010-01-01 |
 
   Scenario: former sprint_start_date and start_date are the same
     When I go to the edit page of the version called "Sprint 001"


### PR DESCRIPTION
Removes the ambiguity of the plugin's cucumber steps with those from the
core when executing cucumber by the core's rake task. Doing so loads all
the step definition leading to the mentioned ambiguity.

This also tries to elevate the scenario description away from web steps
to steps having a specification character.
