### PR TITLE
adapts some cuke scenarios to core's changed i18n behaviour

### DIFF
--- a/features/issue_hierarchy_restriction_project_boundaries.feature
+++ b/features/issue_hierarchy_restriction_project_boundaries.feature
@@ -54,6 +54,7 @@ Feature: The issue hierarchy between backlogs stories and backlogs tasks can not
         | backlogs |
     And the user "markus" is a "scrum master" in the project "parent_project"
     And the user "markus" is a "scrum master" in the project "child_project"
+    And the "cross_project_issue_relations" setting is set to true
     And I am already logged in as "markus"
 
   @javascript

--- a/features/scrum_master.feature
+++ b/features/scrum_master.feature
@@ -125,7 +125,7 @@ Feature: Scrum Master
     And I press "OK"
     Then I should see "Bad Company" within "#impediments"
     And the impediment "Bad Company" should signal unsuccessful saving
-    And the error alert should show "Blocks (IDs) can only contain the IDs of current sprint's tickets"
+    And the error alert should show "Blocks can only contain the IDs of current sprint's tickets"
 
   @javascript
   Scenario: Create an impediment blocking a non existent issue
@@ -137,7 +137,7 @@ Feature: Scrum Master
     And I press "OK"
     Then I should see "Bad Company" within "#impediments"
     And the impediment "Bad Company" should signal unsuccessful saving
-    And the error alert should show "Blocks (IDs) can only contain the IDs of current sprint's tickets"
+    And the error alert should show "Blocks can only contain the IDs of current sprint's tickets"
 
   @javascript
   Scenario: Create an impediment without specifying what it blocks
@@ -149,7 +149,7 @@ Feature: Scrum Master
     And I press "OK"
     Then I should see "Bad Company" within "#impediments"
     And the impediment "Bad Company" should signal unsuccessful saving
-    And the error alert should show "Blocks (IDs) must contain the ID of at least one ticket"
+    And the error alert should show "Blocks must contain the ID of at least one ticket"
 
   @javascript
   Scenario: Update an impediment
@@ -170,7 +170,7 @@ Feature: Scrum Master
     And I press "OK"
     Then I should see "Bad Company" within "#impediments"
     And the impediment "Bad Company" should signal unsuccessful saving
-    And the error alert should show "Blocks (IDs) can only contain the IDs of current sprint's tickets"
+    And the error alert should show "Blocks can only contain the IDs of current sprint's tickets"
 
   @javascript
   Scenario: Update an impediment to block a non existent issue
@@ -181,7 +181,7 @@ Feature: Scrum Master
     And I press "OK"
     Then I should see "Bad Company" within "#impediments"
     And the impediment "Bad Company" should signal unsuccessful saving
-    And the error alert should show "Blocks (IDs) can only contain the IDs of current sprint's tickets"
+    And the error alert should show "Blocks can only contain the IDs of current sprint's tickets"
 
   @javascript
   Scenario: Update an impediment to not block anything
@@ -192,7 +192,7 @@ Feature: Scrum Master
     And I press "OK"
     Then I should see "Bad Company" within "#impediments"
     And the impediment "Bad Company" should signal unsuccessful saving
-    And the error alert should show "Blocks (IDs) must contain the ID of at least one ticket"
+    And the error alert should show "Blocks must contain the ID of at least one ticket"
 
   Scenario: Update sprint details
     Given I am on the master backlog

--- a/features/step_definitions/_then_steps.rb
+++ b/features/step_definitions/_then_steps.rb
@@ -240,5 +240,5 @@ Then /^there should not be a saving error on task "(.+?)"$/ do |task_name|
 end
 
 Then /^I should be notified that the issue "(.+?)" is an invalid parent to the issue "(.+?)" because of cross project limitations$/ do |parent_name, child_name|
-  step %Q{I should see "#{I18n.t(:field_parent_issue)} is invalid because the issue '#{child_name}' is a backlogs task and as such can not have the backlogs story '#{parent_name}' as it´s parent as long as the story is in a different project" within "#errorExplanation"}
+  step %Q{I should see "#{Issue.human_attribute_name(:parent_issue)} is invalid because the issue '#{child_name}' is a backlogs task and as such can not have the backlogs story '#{parent_name}' as it´s parent as long as the story is in a different project" within "#errorExplanation"}
 end


### PR DESCRIPTION
Adapts some cukes to core.

Please note, that this pull request is dependent on some translation changes in the core, so merging this PR will not fix the cukes for now. I will issue another PR for the core, note the PR number and report here once this can be merged.
