### PR TITLE
Changed label name for backlogs column display to prevent mixing up

### DIFF
--- a/app/helpers/version_settings_helper.rb
+++ b/app/helpers/version_settings_helper.rb
@@ -5,7 +5,7 @@ module VersionSettingsHelper
     setting = version_setting_for_project(version, project)
 
     ret = "<p>"
-    ret += label_tag name_for_setting_attributes("display"), l(:label_display)
+    ret += label_tag name_for_setting_attributes("display"), l(:label_column_in_backlog)
     ret += select_tag name_for_setting_attributes("display"), options_for_select(position_display_options, setting.display)
     ret += hidden_field_tag name_for_setting_attributes("id"), setting.id if setting.id
     ret += hidden_field_tag "project_id", project.id

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -95,7 +95,7 @@ de:
   label_blocks_ids: "Blockiert (IDs)"
   label_burndown: "Burndown"
   label_chart_options: "Chart-Optionen"
-  label_display: "Spalte im Backlog"
+  label_column_in_backlog: "Spalte im Backlog"
   label_hours: "Stunden"
   label_issue_hierarchy: "Tickethierarchie"
   label_master_backlog: "Master Backlog"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,7 +95,7 @@ en:
   label_blocks_ids: "Blocks (IDs)"
   label_burndown: "Burndown"
   label_chart_options: "Chart Options"
-  label_display: "Column in backlog"
+  label_column_in_backlog: "Column in backlog"
   label_hours: "hours"
   label_issue_hierarchy: "Issue Hierarchy"
   label_master_backlog: "Master Backlog"


### PR DESCRIPTION
with core label_display key
