### PR TITLE
Fix sometimes failing edit via modal cuke

### DIFF
--- a/app/assets/javascripts/backlogs/modal.js
+++ b/app/assets/javascripts/backlogs/modal.js
@@ -84,9 +84,7 @@ var Backlogs = (function () {
 
   ModalLink = Class.create({
     initialize : function (element) {
-      // setTimeout to please IE7. Otherwise, the element might not be there
-      // yet.
-      setTimeout(this.observeMouseOver.bind(this, element), 100);
+      this.observeMouseOver(element);
     },
 
     observeMouseOver : function (element) {


### PR DESCRIPTION
Don't use setTimeout when binding the issue links, but bind them immediately.
This was a workaround for IE7, which we no longer support.
