### PR TITLE
[FIX] Invalid work package status transitions

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -41,6 +41,7 @@ See doc/COPYRIGHT.rdoc for more details.
 * `#2167` [Accessibility] Link form elements to their label - backlogs - new task
 * `#2258` [Accessibility] linearisation of issue show form
 * `#2607` [Agile] Display Storypoints in Taskboard view
+* `#3532` Fix: [API] It is possible to set statuses that are not allowed by the workflow
 * `#3649` A backlog item should get the highest position when moved to another backlog
 
 ## 3.0.5.pre1

--- a/features/edit_story_tracker_and_status.feature
+++ b/features/edit_story_tracker_and_status.feature
@@ -77,11 +77,10 @@ Feature: Edit story type and status
     And there is a default issuepriority with:
         | name   | Normal |
     And the project has the following stories in the following sprints:
-        | subject | sprint     | type | story_points |
-        | Story A | Sprint 001 | Bug     | 10           |
-        | Story B | Sprint 001 | Story   | 20           |
-        | Story C | Sprint 001 | Bug     | 20           |
-    And the status of "Story C" is "Resolved"
+        | subject | sprint     | type  | status | story_points |
+        | Story A | Sprint 001 | Bug   | New    | 10           |
+        | Story B | Sprint 001 | Story | New    | 20           |
+        | Story C | Sprint 001 | Bug   | New    | 20           |
     And the Type "Story" has for the Role "manager" the following workflows:
         | old_status | new_status |
         | New        | Rejected   |
@@ -141,13 +140,18 @@ Feature: Edit story type and status
 
   @javascript
   Scenario: Edit a story having no permission for the status of the current ticket
-     When I click on the text "Story C"
+     When the Type "Bug" has for the Role "manager" the following workflows:
+        | old_status | new_status |
+        | New        | Resolved   |
+      And I am on the master backlog
+      And I click on the text "Story C"
 
      Then the available status of the story called "Story C" should be the following:
         | New      |
         | Resolved |
 
-     When I confirm the story form
+     When I select "Resolved" from "status_id"
+      And I confirm the story form
 
      Then the displayed attributes of the story called "Story C" should be the following:
         | Status | Resolved |

--- a/spec/models/burndown_spec.rb
+++ b/spec/models/burndown_spec.rb
@@ -80,14 +80,12 @@ describe Burndown do
 
     project.save!
 
-    [issue_open, issue_closed, issue_resolved].combination(2).each do |transition|
-      (transition << transition[0]).each_cons(2) do |slice|
-        FactoryGirl.create(:workflow,
-                           old_status: slice[0],
-                           new_status: slice[1],
-                           role: role,
-                           type_id: type_feature.id)
-      end
+    [issue_open, issue_closed, issue_resolved].permutation(2).each do |transition|
+      FactoryGirl.create(:workflow,
+                         old_status: transition[0],
+                         new_status: transition[1],
+                         role: role,
+                         type_id: type_feature.id)
     end
   end
 

--- a/spec/models/burndown_spec.rb
+++ b/spec/models/burndown_spec.rb
@@ -69,6 +69,8 @@ describe Burndown do
   before(:each) do
     Rails.cache.clear
 
+    User.stub(:current).and_return(user)
+
     Setting.plugin_openproject_backlogs = {"points_burn_direction" => "down",
                                            "wiki_template"         => "",
                                            "card_spec"             => "Sattleford VM-5040",
@@ -77,6 +79,16 @@ describe Burndown do
 
 
     project.save!
+
+    [issue_open, issue_closed, issue_resolved].combination(2).each do |transition|
+      (transition << transition[0]).each_cons(2) do |slice|
+        FactoryGirl.create(:workflow,
+                           old_status: slice[0],
+                           new_status: slice[1],
+                           role: role,
+                           type_id: type_feature.id)
+      end
+    end
   end
 
   describe "Sprint Burndown" do


### PR DESCRIPTION
Implements [ticket 3532](https://www.openproject.org/work_packages/3532)

This PR is related to [openproject core PR 782](https://github.com/opf/openproject/pull/782)
