### PR TITLE
fix #2674 - wrong order of statuses in taskboard

### DIFF
--- a/app/controllers/rb_taskboards_controller.rb
+++ b/app/controllers/rb_taskboards_controller.rb
@@ -41,7 +41,7 @@ class RbTaskboardsController < RbApplicationController
   helper :taskboards
 
   def show
-    @statuses     = Type.find_by_id(Task.type).statuses
+    @statuses     = Type.find_by_id(Task.type).statuses.order(:position)
     @story_ids    = @sprint.stories(@project).map{|s| s.id}
     @last_updated = Task.find(:first,
                               :conditions => ["parent_id in (?)", @story_ids],

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -36,6 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 # Changelog
 
+* `#2674` Wrong order of statuses in taskboard
 * `#3440` New workpackage form layout
 * `#4118` [FIX] Add missing labels
 * `#4152` Page not found when only one export card configuration is specified


### PR DESCRIPTION
see: https://www.openproject.org/work_packages/2674
