### PR TITLE
fix #2526

### DIFF
--- a/lib/open_project/backlogs/burndown/series_raw_data.rb
+++ b/lib/open_project/backlogs/burndown/series_raw_data.rb
@@ -93,7 +93,7 @@ module OpenProject::Backlogs::Burndown
     end
 
     def data_for_dates(dates)
-
+      return [] if dates.empty?
       query_string = <<-SQL
       SELECT
         date_journals.date,
@@ -120,6 +120,8 @@ module OpenProject::Backlogs::Burndown
     end
 
     def authoritative_journal_for_date(dates)
+      raise 'dates must not be empty!' if dates.empty?
+
       query = <<-SQL
       SELECT
         d.date,
@@ -153,6 +155,8 @@ module OpenProject::Backlogs::Burndown
     end
 
     def dates_of_interest_join_table(dates)
+      raise 'dates must not be empty!' if dates.empty?
+
       @date_join ||= dates.map do |date|
         "SELECT CAST('#{date}' AS DATE) AS date"
       end.join(" UNION ")

--- a/spec/models/burndown_spec.rb
+++ b/spec/models/burndown_spec.rb
@@ -96,6 +96,18 @@ describe Burndown do
         Date.stub(:today).and_return(Date.civil(2011,04,04))
       end
 
+      describe "WITH having a version in the future" do
+        before(:each) do
+          version.start_date = Date.today + 1.days
+          version.effective_date = Date.today + 6.days
+          version.save!
+        end
+
+        it "should generate a burndown" do
+          sprint.burndown(project).series[:story_points].should be_empty
+        end
+      end
+
       describe "WITH having a 10 (working days) sprint and being 5 (working) days into it" do
         before(:each) do
           version.start_date = Date.today - 7.days


### PR DESCRIPTION
Burndown chart for future versions not working 

see: https://www.openproject.org/work_packages/2526

suggested changelog entry:

<pre>* `#2526` Burndown chart for future versions not working</pre>
