### PR TITLE
[Feature] 14007 show backlogs attributes in overview tab

### DIFF
--- a/config/locales/js-de.yml
+++ b/config/locales/js-de.yml
@@ -1,0 +1,41 @@
+#-- copyright
+# OpenProject Backlogs Plugin
+#
+# Copyright (C)2013-2014 the OpenProject Foundation (OPF)
+# Copyright (C)2011 Stephan Eckardt, Tim Felgentreff, Marnen Laibow-Koser, Sandro Munda
+# Copyright (C)2010-2011 friflaj
+# Copyright (C)2010 Maxime Guilbot, Andrew Vit, Joakim Kolsjö, ibussieres, Daniel Passos, Jason Vasquez, jpic, Emiliano Heyns
+# Copyright (C)2009-2010 Mark Maglana
+# Copyright (C)2009 Joe Heck, Nate Lowrie
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3.
+#
+# OpenProject Backlogs is a derivative work based on ChiliProject Backlogs.
+# The copyright follows:
+# Copyright (C) 2010-2011 - Emiliano Heyns, Mark Maglana, friflaj
+# Copyright (C) 2011 - Jens Ulferts, Gregor Schmidt - Finn GmbH - Berlin, Germany
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+de:
+  js:
+    work_packages:
+      properties:
+        storyPoints: "Story Punkte"
+        remainingHours: "Verbleibende Stunden"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1,0 +1,41 @@
+#-- copyright
+# OpenProject Backlogs Plugin
+#
+# Copyright (C)2013-2014 the OpenProject Foundation (OPF)
+# Copyright (C)2011 Stephan Eckardt, Tim Felgentreff, Marnen Laibow-Koser, Sandro Munda
+# Copyright (C)2010-2011 friflaj
+# Copyright (C)2010 Maxime Guilbot, Andrew Vit, Joakim Kolsjö, ibussieres, Daniel Passos, Jason Vasquez, jpic, Emiliano Heyns
+# Copyright (C)2009-2010 Mark Maglana
+# Copyright (C)2009 Joe Heck, Nate Lowrie
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License version 3.
+#
+# OpenProject Backlogs is a derivative work based on ChiliProject Backlogs.
+# The copyright follows:
+# Copyright (C) 2010-2011 - Emiliano Heyns, Mark Maglana, friflaj
+# Copyright (C) 2011 - Jens Ulferts, Gregor Schmidt - Finn GmbH - Berlin, Germany
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+en:
+  js:
+    work_packages:
+      properties:
+        storyPoints: "Story Points"
+        remainingHours: "Remaining Hours"

--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -131,6 +131,19 @@ module OpenProject::Backlogs
     patches [:PermittedParams, :WorkPackage, :Status, :MyController, :Project,
       :ProjectsController, :ProjectsHelper, :Query, :User, :VersionsController, :Version]
 
+    extend_api_response(:v3, :work_packages, :work_package) do
+      property :story_points, exec_context: :decorator, if: -> (*) { represented.work_package.backlogs_enabled? }
+      property :remaining_hours, exec_context: :decorator, if: -> (*) { represented.work_package.backlogs_enabled? }
+
+      send(:define_method, :story_points) do
+        represented.work_package.story_points
+      end
+
+      send(:define_method, :remaining_hours) do
+        represented.work_package.remaining_hours
+      end
+    end
+
     config.to_prepare do
       if WorkPackage.const_defined? "SAFE_ATTRIBUTES"
         WorkPackage::SAFE_ATTRIBUTES << "story_points"

--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -117,7 +117,7 @@ module OpenProject::Backlogs
         :param => :project_id,
         :if => proc { not(User.current.respond_to?(:impaired?) and User.current.impaired?) },
         :html => {:class => 'icon2 icon-backlogs-icon'}
-      end
+    end
 
     assets %w(
       backlogs/backlogs.css

--- a/lib/open_project/backlogs/hooks.rb
+++ b/lib/open_project/backlogs/hooks.rb
@@ -52,6 +52,18 @@ module OpenProject::Backlogs::Hooks
       attributes
     end
 
+    def work_packages_overview_attributes(context = {})
+      work_package = context[:work_package]
+      attributes = context[:attributes]
+
+      return unless work_package.backlogs_enabled?
+
+      attributes << :storyPoints
+      attributes << :remainingHours
+
+      attributes
+    end
+
     private
 
     def work_package_show_story_points_attribute(work_package)

--- a/lib/open_project/backlogs/hooks.rb
+++ b/lib/open_project/backlogs/hooks.rb
@@ -53,10 +53,10 @@ module OpenProject::Backlogs::Hooks
     end
 
     def work_packages_overview_attributes(context = {})
-      work_package = context[:work_package]
+      project = context[:project]
       attributes = context[:attributes]
 
-      return unless work_package.backlogs_enabled?
+      return unless project && project.module_enabled?(:backlogs)
 
       attributes << :storyPoints
       attributes << :remainingHours

--- a/spec/api/work_package_resource_spec.rb
+++ b/spec/api/work_package_resource_spec.rb
@@ -1,0 +1,72 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 Work package resource' do
+  include Rack::Test::Methods
+  include Capybara::RSpecMatchers
+
+  let(:admin) { FactoryGirl.create(:admin) }
+  let(:project) { FactoryGirl.create(:project) }
+  let(:work_package) { FactoryGirl.create(:work_package,
+                                          project: project,
+                                          story_points: 8,
+                                          remaining_hours: 5) }
+
+  describe '#get' do
+    shared_context 'query work package' do
+      before do
+        allow(User).to receive(:current).and_return(admin)
+        get "/api/v3/work_packages/#{work_package.id}"
+      end
+
+      subject(:parsed_response) { JSON.parse(last_response.body) }
+    end
+
+    context 'backlogs activated' do
+      include_context 'query work package'
+
+      it { expect(parsed_response['storyPoints']).to eq(work_package.story_points) }
+
+      it { expect(parsed_response['remainingHours']).to eq(work_package.remaining_hours) }
+    end
+
+    context 'backlogs deactivated' do
+      let(:project) { FactoryGirl.create(:project,
+                                         enabled_module_names: []) }
+
+      include_context 'query work package'
+
+      it { expect(parsed_response['storyPoints']).to be_nil }
+
+      it { expect(parsed_response['remainingHours']).to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
[`* `#14007` Enable extension of API v3 and work package overview`](https://www.openproject.org/work_packages/14007)

:exclamation: Depends on [Core PR 1683](https://github.com/opf/openproject/pull/1683)
