### PR TITLE
[Foundation] Use the new form styles in form helper for backlogs

### DIFF
--- a/app/helpers/version_settings_helper.rb
+++ b/app/helpers/version_settings_helper.rb
@@ -39,17 +39,22 @@ module VersionSettingsHelper
   def version_settings_fields(version, project)
     setting = version_setting_for_project(version, project)
 
-    ret = "<p>"
-    ret += label_tag name_for_setting_attributes("display"), l(:label_column_in_backlog)
-    ret += select_tag name_for_setting_attributes("display"), options_for_select(position_display_options, setting.display)
-    ret += hidden_field_tag name_for_setting_attributes("id"), setting.id if setting.id
-    ret += hidden_field_tag "project_id", project.id
-    ret += "</p>"
-
-    ret.html_safe
+    content_tag :div, class: 'form--field' do
+      [
+        styled_label_tag(name_for_setting_attributes('display'), l(:label_column_in_backlog)),
+        styled_select_tag(name_for_setting_attributes('display'), options_for_select(position_display_options, setting.display)),
+        version_hidden_id_field(setting),
+        hidden_field_tag('project_id', project.id)
+      ].join.html_safe
+    end
   end
 
   private
+
+  def version_hidden_id_field(setting)
+    return '' unless setting.id
+    hidden_field_tag(name_for_setting_attributes("id"), setting.id)
+  end
 
   def version_setting_for_project(version, project)
     setting = version.version_settings.detect { |vs| vs.project_id == project.id || vs.project_id.nil? }

--- a/app/views/versions/_form.html.erb
+++ b/app/views/versions/_form.html.erb
@@ -62,7 +62,9 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <% if @project.enabled_modules.collect(&:name).include?("backlogs") %>
-  <%= version_settings_fields @version, @project %>
+
+  <%= version_settings_fields(@version, @project).html_safe %>
+
 <% end %>
 
 <% if @version.project == @project %>


### PR DESCRIPTION
This will use the new form styles in the version settings and correct an issue found within https://community.openproject.org/work_packages/19205
