### PR TITLE
Only show story points and remaining time when intended

### DIFF
--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -147,7 +147,7 @@ module OpenProject::Backlogs
     extend_api_response(:v3, :work_packages, :work_package) do
       property :story_points,
                render_nil: true,
-               if: -> (*) { backlogs_enabled? && type.backlogs_type? }
+               if: -> (*) { backlogs_enabled? && type.story? }
 
       property :remaining_time,
                exec_context: :decorator,
@@ -155,13 +155,14 @@ module OpenProject::Backlogs
                  datetime_formatter.format_duration_from_hours(represented.remaining_hours,
                                                                allow_nil: true)
                },
-               render_nil: true
+               render_nil: true,
+               if: -> (*) { represented.backlogs_enabled? }
     end
 
     extend_api_response(:v3, :work_packages, :form, :work_package_payload) do
       property :story_points,
                render_nil: true,
-               if: -> (*) { backlogs_enabled? && type.backlogs_type? }
+               if: -> (*) { backlogs_enabled? && type.story? }
 
       property :remaining_time,
                exec_context: :decorator,
@@ -175,7 +176,8 @@ module OpenProject::Backlogs
                                                                         allow_nil: true)
                  represented.remaining_hours = remaining
                },
-               render_nil: true
+               render_nil: true,
+               if: -> (*) { represented.backlogs_enabled? }
     end
 
     extend_api_response(:v3, :work_packages, :schema, :work_package_schema) do
@@ -183,14 +185,17 @@ module OpenProject::Backlogs
              type: 'Integer',
              required: false,
              show_if: -> (*) {
-               represented.project.backlogs_enabled? && represented.type.backlogs_type?
+               represented.project.backlogs_enabled? && represented.type.story?
              }
 
       schema :remaining_time,
              type: 'Duration',
              name_source: :remaining_hours,
              required: false,
-             writable: -> (*) { represented.remaining_time_writable? }
+             writable: -> (*) { represented.remaining_time_writable? },
+             show_if: -> (*) {
+               represented.project.backlogs_enabled?
+             }
     end
 
     allow_attribute_update :work_package, :story_points

--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -193,9 +193,7 @@ module OpenProject::Backlogs
              name_source: :remaining_hours,
              required: false,
              writable: -> (*) { represented.remaining_time_writable? },
-             show_if: -> (*) {
-               represented.project.backlogs_enabled?
-             }
+             show_if: -> (*) { represented.project.backlogs_enabled? }
     end
 
     allow_attribute_update :work_package, :story_points

--- a/lib/open_project/backlogs/patches/type_patch.rb
+++ b/lib/open_project/backlogs/patches/type_patch.rb
@@ -56,9 +56,5 @@ module OpenProject::Backlogs::Patches::TypePatch
     def task?
       Task.type.present? && id == Task.type
     end
-
-    def backlogs_type?
-      story? || task?
-    end
   end
 end

--- a/spec/api/work_package_resource_spec.rb
+++ b/spec/api/work_package_resource_spec.rb
@@ -83,7 +83,7 @@ describe 'API v3 Work package resource' do
 
       it { is_expected.not_to have_json_path('storyPoints') }
 
-      it { is_expected.to be_json_eql('PT5H'.to_json).at_path('remainingTime') }
+      it { is_expected.not_to have_json_path('remainingTime') }
     end
   end
 

--- a/spec/api/work_package_schema_representer_spec.rb
+++ b/spec/api/work_package_schema_representer_spec.rb
@@ -41,7 +41,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
   before do
     allow(schema.project).to receive(:backlogs_enabled?).and_return(true)
-    allow(work_package.type).to receive(:backlogs_type?).and_return(true)
+    allow(work_package.type).to receive(:story?).and_return(true)
   end
 
   describe 'storyPoints' do
@@ -65,9 +65,9 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
       end
     end
 
-    context 'not a backlogs type' do
+    context 'not a story' do
       before do
-        allow(schema.type).to receive(:backlogs_type?).and_return(false)
+        allow(schema.type).to receive(:story?).and_return(false)
       end
 
       it 'does not show story points' do
@@ -100,12 +100,14 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         allow(schema.project).to receive(:backlogs_enabled?).and_return(false)
       end
 
-      it_behaves_like 'has schema for remainingTime'
+      it 'has no schema for remaining time' do
+        is_expected.not_to have_json_path('remainingTime')
+      end
     end
 
-    context 'not a backlogs type' do
+    context 'not a story' do
       before do
-        allow(schema.type).to receive(:backlogs_type?).and_return(false)
+        allow(schema.type).to receive(:story?).and_return(false)
       end
 
       it_behaves_like 'has schema for remainingTime'


### PR DESCRIPTION
## OpenProject Work Package

https://community.openproject.org/work_packages/19302
## Description

there was some confusion about when both should be visible and when not.
We now ake the behaviour observed in the existing implementation:
- never display when backlogs deactivated
- story points only for stories
- remaining hours for everything (if backlogs is activated)
