### PR TITLE
Merge dev back into release 4.1

### DIFF
--- a/app/assets/stylesheets/backlogs/global.css
+++ b/app/assets/stylesheets/backlogs/global.css
@@ -64,3 +64,16 @@ See doc/COPYRIGHT.rdoc for more details.
 th {
   font-weight: bold;
 }
+
+#col_width label {
+  display: inline-block;
+  float: left;
+  line-height: 40px;
+  margin: 0 15px;
+}
+
+#col_width_input {
+  display: inline-block;
+  float: right;
+  margin: 0;
+}

--- a/app/assets/stylesheets/backlogs/taskboard.css.sass
+++ b/app/assets/stylesheets/backlogs/taskboard.css.sass
@@ -74,7 +74,7 @@
   .swimlane
     min-width: 105px
     /* width + (2*margin) + (2*padding) + (2*border) of .work_package
-    padding: 5px
+    padding: 5px 0 0 5px
     width: 105px
     /* Must be the same as min-width
   #board_header
@@ -89,10 +89,12 @@
       font-weight: bold
       text-align: center
       vertical-align: middle
+      padding-top: 0
+      padding-bottom: 0
+      line-height: 30px
       &:first-child
-        min-width: 231px
-        padding: 6px 10px 6px 10px
-        width: 231px
+        min-width: 241px
+        width: 241px
       &:last-child
         border-right: none
   .board
@@ -140,12 +142,12 @@
     width: 190px
   .story
     .subject
-      height: 52px
+      height: 42px
       line-height: 13px
       margin-top: 0
       overflow: hidden
       padding: 2px
-      width: 186px
+      width: 180px
     &.closed .subject
       text-decoration: line-through
   .work_package, .placeholder
@@ -308,7 +310,7 @@
   .story-bar
     @include story-header
     text-align: right
-    width: 187px
+    width: 180px
     clear: both
     .id
       float: right
@@ -323,7 +325,7 @@
   .id
     @include story-header
     text-align: right
-    width: 82px
+    width: 75px
     a
       opacity: 1.0
       filter: alpha(opacity = 100)
@@ -331,7 +333,7 @@
     background-color: transparent
   .subject.editable
     font-size: 1rem - rem-calc(3px)
-    height: 52px
+    height: 42px
     line-height: 13px
     margin-top: 0
     overflow: hidden

--- a/app/views/rb_burndown_charts/show.html.erb
+++ b/app/views/rb_burndown_charts/show.html.erb
@@ -43,8 +43,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <div class="burndown_chart" id="burndown_<%= @burndown.sprint_id %>" style="width:600px;height:300px;"><div class="loading"><%=l('backlogs.generating_chart')%></div></div>
 
-  <fieldset class="burndown_control">
-      <legend><%= l('backlogs.chart_options') %></legend>
+  <fieldset class="burndown_control form--fieldset">
+      <legend class="form--fieldset-legend"><%= l('backlogs.chart_options') %></legend>
       <%= burndown_series_checkboxes(@burndown) %>
   </fieldset>
 <% else %>

--- a/app/views/rb_burndown_charts/show.html.erb
+++ b/app/views/rb_burndown_charts/show.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <div class="burndown_chart" id="burndown_<%= @burndown.sprint_id %>" style="width:600px;height:300px;"><div class="loading"><%=l('backlogs.generating_chart')%></div></div>
 
-  <fieldset class="burndown_control form--fieldset">
+  <fieldset class="form--fieldset">
       <legend class="form--fieldset-legend"><%= l('backlogs.chart_options') %></legend>
       <%= burndown_series_checkboxes(@burndown) %>
   </fieldset>

--- a/features/fixed_version_by_issue_hierarchy.feature
+++ b/features/fixed_version_by_issue_hierarchy.feature
@@ -143,7 +143,7 @@ Feature: The work_package hierarchy defines the allowed versions for each work_p
       And I select "Task" from "work_package_type_id"
       And I fill in "Task 0815" for "work_package_subject"
       And I click on the first button matching "Create"
-     Then I should see "Sprint 001" within "td.work_package_attribute_header.fixed-version + td.fixed-version"
+     Then I should see "Sprint 001" within "dd.-fixed-version"
 
   Scenario: Creating a task, via new work_package, as a subtask to a story set´s the new task´s fixed version to the parent´s fixed version
      When I go to the new work_package page of the project called "ecookbook"
@@ -151,7 +151,7 @@ Feature: The work_package hierarchy defines the allowed versions for each work_p
       And I fill in "Task 0815" for "work_package_subject"
       And I fill in the id of the work_package "Story A" as the parent work_package
       And I click on the first button matching "Create"
-     Then I should see "Sprint 001" within "td.work_package_attribute_header.fixed-version + td.fixed-version"
+     Then I should see "Sprint 001" within "dd.-fixed-version"
 
   Scenario: Creating a task, via new work_package, as a subtask to a story and setting a fixed version is overriden by the parent´s fixed version (bug 8904)
      When I go to the new work_package page of the project called "ecookbook"
@@ -160,7 +160,7 @@ Feature: The work_package hierarchy defines the allowed versions for each work_p
       And I fill in the id of the work_package "Story A" as the parent work_package
       And I select "Sprint 003" from "work_package_fixed_version_id"
       And I click on the first button matching "Create"
-     Then I should see "Sprint 001" within "td.work_package_attribute_header.fixed-version + td.fixed-version"
+     Then I should see "Sprint 001" within "dd.-fixed-version"
 
   Scenario: Moving a task between stories via work_package/edit (bug 9324)
     Given the project has the following tasks:
@@ -169,7 +169,7 @@ Feature: The work_package hierarchy defines the allowed versions for each work_p
     When I go to the edit page of the work_package "Task 1"
      And I fill in the id of the work_package "Story C" as the parent work_package
      And I press "Submit"
-    Then I should see "Sprint 002" within "td.work_package_attribute_header.fixed-version + td.fixed-version"
+    Then I should see "Sprint 002" within "dd.-fixed-version"
 
   Scenario: Changing the fixed_version of a task with a non backlogs parent work_package (bug 8354)
     Given the project has the following work_packages:

--- a/features/fixed_version_by_issue_hierarchy.feature
+++ b/features/fixed_version_by_issue_hierarchy.feature
@@ -143,7 +143,7 @@ Feature: The work_package hierarchy defines the allowed versions for each work_p
       And I select "Task" from "work_package_type_id"
       And I fill in "Task 0815" for "work_package_subject"
       And I click on the first button matching "Create"
-     Then I should see "Sprint 001" within "dd.-fixed-version"
+     Then I should see "Sprint 001" within ".work_package.details dd.-fixed-version"
 
   Scenario: Creating a task, via new work_package, as a subtask to a story set´s the new task´s fixed version to the parent´s fixed version
      When I go to the new work_package page of the project called "ecookbook"
@@ -151,7 +151,7 @@ Feature: The work_package hierarchy defines the allowed versions for each work_p
       And I fill in "Task 0815" for "work_package_subject"
       And I fill in the id of the work_package "Story A" as the parent work_package
       And I click on the first button matching "Create"
-     Then I should see "Sprint 001" within "dd.-fixed-version"
+     Then I should see "Sprint 001" within ".work_package.details dd.-fixed-version"
 
   Scenario: Creating a task, via new work_package, as a subtask to a story and setting a fixed version is overriden by the parent´s fixed version (bug 8904)
      When I go to the new work_package page of the project called "ecookbook"
@@ -160,7 +160,7 @@ Feature: The work_package hierarchy defines the allowed versions for each work_p
       And I fill in the id of the work_package "Story A" as the parent work_package
       And I select "Sprint 003" from "work_package_fixed_version_id"
       And I click on the first button matching "Create"
-     Then I should see "Sprint 001" within "dd.-fixed-version"
+     Then I should see "Sprint 001" within ".work_package.details dd.-fixed-version"
 
   Scenario: Moving a task between stories via work_package/edit (bug 9324)
     Given the project has the following tasks:
@@ -169,7 +169,7 @@ Feature: The work_package hierarchy defines the allowed versions for each work_p
     When I go to the edit page of the work_package "Task 1"
      And I fill in the id of the work_package "Story C" as the parent work_package
      And I press "Submit"
-    Then I should see "Sprint 002" within "dd.-fixed-version"
+    Then I should see "Sprint 002" within ".work_package.details dd.-fixed-version"
 
   Scenario: Changing the fixed_version of a task with a non backlogs parent work_package (bug 8354)
     Given the project has the following work_packages:

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -81,7 +81,7 @@ describe WorkPackagesController, :type => :controller do
 
       subject { response.body }
 
-      it { is_expected.to have_selector('.work_package.details .-story-points', text: story_points.to_s) }
+      it { is_expected.to have_selector('.work_package.details dd.-story-points', text: story_points.to_s) }
     end
   end
 

--- a/spec/controllers/work_packages_controller_spec.rb
+++ b/spec/controllers/work_packages_controller_spec.rb
@@ -81,7 +81,7 @@ describe WorkPackagesController, :type => :controller do
 
       subject { response.body }
 
-      it { is_expected.to have_selector('table.attributes td.work_package_attribute_header + td.story-points', text: story_points.to_s) }
+      it { is_expected.to have_selector('.work_package.details .-story-points', text: story_points.to_s) }
     end
   end
 

--- a/spec/views/work_package/show.html.erb_spec.rb
+++ b/spec/views/work_package/show.html.erb_spec.rb
@@ -56,6 +56,6 @@ describe 'work_packages/show', :type => :view do
       render partial: 'work_packages/show_attributes', locals: { work_package: story }
     end
 
-    it { expect(rendered).to have_selector('.work_package.details .-story-points', text: story_points.to_s) }
+    it { expect(rendered).to have_selector('.work_package.details dd.-story-points', text: story_points.to_s) }
   end
 end

--- a/spec/views/work_package/show.html.erb_spec.rb
+++ b/spec/views/work_package/show.html.erb_spec.rb
@@ -56,6 +56,6 @@ describe 'work_packages/show', :type => :view do
       render partial: 'work_packages/show_attributes', locals: { work_package: story }
     end
 
-    it { expect(rendered).to have_selector('table.attributes td.work_package_attribute_header + td.story-points', text: story_points.to_s) }
+    it { expect(rendered).to have_selector('.work_package.details .-story-points', text: story_points.to_s) }
   end
 end


### PR DESCRIPTION
We accidentally merged PRs against `dev` which were required for `release/4.1`

This PR is to check for any commits that might have no place in `release/4.1`. Otherwise, `release/4.1` can also be rebased on `dev`
