### PR TITLE
[18330] Use toolbar component in the plugin

### DIFF
--- a/app/views/projects/settings/_backlogs_settings.html.erb
+++ b/app/views/projects/settings/_backlogs_settings.html.erb
@@ -26,8 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-
-<h2><%=l('backlogs.definition_of_done')%></h2>
+<%= toolbar title:l('backlogs.definition_of_done')  %>
 
 <% statuses_done_for_project = @project.done_statuses.select(:id).map(&:id) %>
 
@@ -59,7 +58,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <p><%= submit_tag l(:button_save), class: 'button -highlight' %></p>
 <% end %>
 
-<h2><%=l('backlogs.rebuild_positions')%></h2>
+<h3><%=l('backlogs.rebuild_positions')%></h3>
 
 <%= styled_form_tag(:controller => '/projects', :action => "rebuild_positions", :id => @project) do %>
   <p><%= submit_tag l('backlogs.rebuild'), class: 'button' %></p>

--- a/app/views/rb_export_card_configurations/index.html.erb
+++ b/app/views/rb_export_card_configurations/index.html.erb
@@ -36,9 +36,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 
 <div class='contextual'></div>
-<h2>
-  <%= l(:label_backlogs_export_card_config_select) %>
-</h2>
+<%= toolbar title: l(:label_backlogs_export_card_config_select) %>
 
 <ul>
 <% @configs.each do |config| %>

--- a/app/views/rb_master_backlogs/index.html.erb
+++ b/app/views/rb_master_backlogs/index.html.erb
@@ -43,9 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <div class='contextual'></div>
-<h2>
-  <%= l(:label_backlogs) %>
-</h2>
+<%= toolbar title: l(:label_backlogs) %>
 
 <div id="rb">
   <div id="backlogs_container" class="clearfix">

--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
                                      :sprint_id => @sprint) %>
 <% end %>
 
-<%= toolbar title: @sprint.name do %>
+<%= toolbar title: h(@sprint.name) do %>
   <% if @sprint.has_burndown? %>
     <li class="toolbar-item">
       <label for="col_width_input"><%= l('backlogs.column_width') %></label>

--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
                                      :sprint_id => @sprint) %>
 <% end %>
 
-<% content_for :toolbar do %>
+<%= toolbar title: @sprint.name do %>
   <% if @sprint.has_burndown? %>
     <li class="toolbar-item">
       <label for="col_width_input"><%= l('backlogs.column_width') %></label>
@@ -58,12 +58,6 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <% breadcrumb_paths(link_to(l(:label_backlogs), backlogs_project_backlogs_path(@project)), link_to(@sprint.name, backlogs_project_backlogs_path(@sprint))) %>
-
-<h2>
-  <%= @sprint.name %>
-</h2>
-
-<%= render :partial => 'layouts/toolbar' %>
 
 <div id='rb'>
   <div id="taskboard">

--- a/app/views/version_settings/edit.html.erb
+++ b/app/views/version_settings/edit.html.erb
@@ -33,8 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-
-<h2><%=l(:label_version)%></h2>
+<%= toolbar title: l(:label_version)  %>
 
 <% labelled_tabular_form_for :version, @version, :url => project_version_path(@project, @version), :html => {:method => :put} do |f| %>
 <%= render :partial => 'form', :locals => { :f => f } %>


### PR DESCRIPTION
This will make use of the toolbar component in the backlogs plugin.

:warning: **This depends on opf/openproject#3000** Review first! :warning: 
