### PR TITLE
[20214] Burndown chart broken

### DIFF
--- a/app/models/burndown.rb
+++ b/app/models/burndown.rb
@@ -107,8 +107,8 @@ class Burndown
 
   def determine_max
     @max = {
-      :points => @available_series.values.select{|s| s.unit == :points}.flatten.compact.max || 0.0,
-      :hours => @available_series.values.select{|s| s.unit == :hours}.flatten.compact.max || 0.0
+      :points => @available_series.values.select{|s| s.unit == :points}.flatten.compact.reject(&:nan?).max || 0.0,
+      :hours => @available_series.values.select{|s| s.unit == :hours}.flatten.compact.reject(&:nan?).max || 0.0
     }
   end
 

--- a/app/views/rb_burndown_charts/show.html.erb
+++ b/app/views/rb_burndown_charts/show.html.erb
@@ -43,7 +43,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
   <div class="burndown_chart" id="burndown_<%= @burndown.sprint_id %>" style="width:600px;height:300px;"><div class="loading"><%=l('backlogs.generating_chart')%></div></div>
 
-  <fieldset class="form--fieldset">
+  <fieldset class="burndown_control form--fieldset">
       <legend class="form--fieldset-legend"><%= l('backlogs.chart_options') %></legend>
       <%= burndown_series_checkboxes(@burndown) %>
   </fieldset>


### PR DESCRIPTION
This addresses the requirements stated in https://community.openproject.org/work_packages/20214.

The bugs were found after @ploffredi reported a missing class in https://github.com/finnlabs/openproject-backlogs/commit/2ecbc7e022b0d858d161ff833c6e540c9b9bcf0f.

It also addresses an issue where the burndown chart could not be loaded when the version had an equal start and end date in the backlogs.
