### PR TITLE
Fix constant reloading issues: remove unloadable

### DIFF
--- a/app/controllers/rb_application_controller.rb
+++ b/app/controllers/rb_application_controller.rb
@@ -35,8 +35,6 @@
 
 # Base class of all controllers in Backlogs
 class RbApplicationController < ApplicationController
-  unloadable
-
   helper :rb_common
 
   before_filter :load_sprint_and_project, :check_if_plugin_is_configured, :authorize

--- a/app/controllers/rb_burndown_charts_controller.rb
+++ b/app/controllers/rb_burndown_charts_controller.rb
@@ -34,8 +34,6 @@
 #++
 
 class RbBurndownChartsController < RbApplicationController
-  unloadable
-
   helper :burndown_charts
 
   def show

--- a/app/controllers/rb_export_card_configurations_controller.rb
+++ b/app/controllers/rb_export_card_configurations_controller.rb
@@ -35,7 +35,6 @@
 
 
 class RbExportCardConfigurationsController < RbApplicationController
-  unloadable
   include OpenProject::PdfExport::ExportCard
 
   before_filter :load_project_and_sprint

--- a/app/controllers/rb_impediments_controller.rb
+++ b/app/controllers/rb_impediments_controller.rb
@@ -34,8 +34,6 @@
 #++
 
 class RbImpedimentsController < RbApplicationController
-  unloadable
-
   def create
     @impediment = Impediment.create_with_relationships(params, @project.id)
     status = (@impediment.errors.empty? ? 200 : 400)

--- a/app/controllers/rb_master_backlogs_controller.rb
+++ b/app/controllers/rb_master_backlogs_controller.rb
@@ -34,8 +34,6 @@
 #++
 
 class RbMasterBacklogsController < RbApplicationController
-  unloadable
-
   menu_item :backlogs
 
   before_filter :set_export_card_config_meta

--- a/app/controllers/rb_queries_controller.rb
+++ b/app/controllers/rb_queries_controller.rb
@@ -34,7 +34,6 @@
 #++
 
 class RbQueriesController < RbApplicationController
-  unloadable
   include WorkPackagesFilterHelper
 
   def show

--- a/app/controllers/rb_server_variables_controller.rb
+++ b/app/controllers/rb_server_variables_controller.rb
@@ -34,8 +34,6 @@
 #++
 
 class RbServerVariablesController < RbApplicationController
-  unloadable
-
   def show
     respond_to do |format|
       format.js { render :layout => false }

--- a/app/controllers/rb_sprints_controller.rb
+++ b/app/controllers/rb_sprints_controller.rb
@@ -38,8 +38,6 @@
 # objects within a sprint. For info about the taskboard, see
 # RbTaskboardsController
 class RbSprintsController < RbApplicationController
-  unloadable
-
   def update
     result  = @sprint.update_attributes(params.slice(:name,
                                                      :start_date,

--- a/app/controllers/rb_stories_controller.rb
+++ b/app/controllers/rb_stories_controller.rb
@@ -34,7 +34,6 @@
 #++
 
 class RbStoriesController < RbApplicationController
-  unloadable
   include OpenProject::PdfExport::ExportCard
 
   def create

--- a/app/controllers/rb_taskboards_controller.rb
+++ b/app/controllers/rb_taskboards_controller.rb
@@ -34,8 +34,6 @@
 #++
 
 class RbTaskboardsController < RbApplicationController
-  unloadable
-
   menu_item :backlogs
 
   helper :taskboards

--- a/app/controllers/rb_tasks_controller.rb
+++ b/app/controllers/rb_tasks_controller.rb
@@ -34,8 +34,6 @@
 #++
 
 class RbTasksController < RbApplicationController
-  unloadable
-
   def create
     @task = Task.create_with_relationships(params, @project.id)
 

--- a/app/controllers/rb_wikis_controller.rb
+++ b/app/controllers/rb_wikis_controller.rb
@@ -34,8 +34,6 @@
 #++
 
 class RbWikisController < RbApplicationController
-  unloadable
-
   # NOTE: The methods #show and #edit are public (see init.rb). We will let
   # OpenProject's WikiController#index take care of autorization
   #

--- a/app/controllers/version_settings_controller.rb
+++ b/app/controllers/version_settings_controller.rb
@@ -34,8 +34,6 @@
 #++
 
 class VersionSettingsController < RbApplicationController
-  unloadable
-
   def edit
     @version = Version.find(params[:id])
   end

--- a/app/controllers/work_package_boxes_controller.rb
+++ b/app/controllers/work_package_boxes_controller.rb
@@ -34,8 +34,6 @@
 #++
 
 class WorkPackageBoxesController < WorkPackagesController
-  unloadable
-
   helper :rb_common
 
   def show

--- a/app/helpers/rb_common_helper.rb
+++ b/app/helpers/rb_common_helper.rb
@@ -34,8 +34,6 @@
 #++
 
 module RbCommonHelper
-  unloadable
-
   def assignee_id_or_empty(story)
     story.assigned_to_id.to_s
   end

--- a/app/helpers/rb_master_backlogs_helper.rb
+++ b/app/helpers/rb_master_backlogs_helper.rb
@@ -34,8 +34,6 @@
 #++
 
 module RbMasterBacklogsHelper
-  unloadable
-
   include Redmine::I18n
 
   def render_backlog_menu(backlog)

--- a/app/helpers/taskboards_helper.rb
+++ b/app/helpers/taskboards_helper.rb
@@ -34,8 +34,6 @@
 #++
 
 module TaskboardsHelper
-  unloadable
-
   def impediments_by_position_for_status sprint, project, status
     sprint.impediments(project).select{ |i| i.status_id == status.id }.sort_by {|i| i.position.present? ? i.position : 0  }
   end

--- a/app/helpers/version_settings_helper.rb
+++ b/app/helpers/version_settings_helper.rb
@@ -34,8 +34,6 @@
 #++
 
 module VersionSettingsHelper
-  unloadable
-
   def version_settings_fields(version, project)
     setting = version_setting_for_project(version, project)
 

--- a/app/models/backlog.rb
+++ b/app/models/backlog.rb
@@ -34,8 +34,6 @@
 #++
 
 class Backlog
-  unloadable
-
   attr_accessor :sprint
   attr_accessor :stories
 

--- a/app/models/burndown.rb
+++ b/app/models/burndown.rb
@@ -34,8 +34,6 @@
 #++
 
 class Burndown
-  unloadable
-
   def initialize(sprint, project, burn_direction = nil)
     burn_direction ||= Setting.plugin_openproject_backlogs["points_burn_direction"]
 

--- a/app/models/impediment.rb
+++ b/app/models/impediment.rb
@@ -34,8 +34,6 @@
 #++
 
 class Impediment < Task
-  unloadable
-
   extend OpenProject::Backlogs::Mixins::PreventIssueSti
 
   after_save :update_blocks_list

--- a/app/models/sprint.rb
+++ b/app/models/sprint.rb
@@ -36,8 +36,6 @@
 require 'date'
 
 class Sprint < Version
-  unloadable
-
   scope :open_sprints, lambda { |project|
     {
       :order => "COALESCE(start_date, CAST('4000-12-30' as date)) ASC, COALESCE(effective_date, CAST('4000-12-30' as date)) ASC",

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -34,8 +34,6 @@
 #++
 
 class Story < WorkPackage
-  unloadable
-
   extend OpenProject::Backlogs::Mixins::PreventIssueSti
 
   def self.backlogs(project_id, sprint_ids, options = {})

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -36,8 +36,6 @@
 require 'date'
 
 class Task < WorkPackage
-  unloadable
-
   extend OpenProject::Backlogs::Mixins::PreventIssueSti
 
   def self.type

--- a/lib/open_project/backlogs/burndown/series.rb
+++ b/lib/open_project/backlogs/burndown/series.rb
@@ -34,8 +34,6 @@
 #++
 
 module OpenProject::Backlogs::Burndown
-  unloadable
-
   class Series < Array
     def initialize(*args)
       @unit = args.pop

--- a/lib/open_project/backlogs/burndown/series_raw_data.rb
+++ b/lib/open_project/backlogs/burndown/series_raw_data.rb
@@ -35,8 +35,6 @@
 
 module OpenProject::Backlogs::Burndown
   class SeriesRawData < Hash
-    unloadable
-
     def initialize(*args)
       @collect = args.pop
       @sprint = args.pop

--- a/lib/open_project/backlogs/list.rb
+++ b/lib/open_project/backlogs/list.rb
@@ -34,12 +34,8 @@
 #++
 
 module OpenProject::Backlogs::List
-  unloadable
-
   def self.included(base)
     base.class_eval do
-      unloadable
-
       acts_as_silent_list
 
       # Reorder list, if work_package is removed from sprint

--- a/lib/open_project/backlogs/patches/my_controller_patch.rb
+++ b/lib/open_project/backlogs/patches/my_controller_patch.rb
@@ -38,8 +38,6 @@ require_dependency 'my_controller'
 module OpenProject::Backlogs::Patches::MyControllerPatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       include InstanceMethods
 
       after_filter :save_backlogs_preferences, :only => [:account]

--- a/lib/open_project/backlogs/patches/project_patch.rb
+++ b/lib/open_project/backlogs/patches/project_patch.rb
@@ -38,8 +38,6 @@ require_dependency 'project'
 module OpenProject::Backlogs::Patches::ProjectPatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       has_and_belongs_to_many :done_statuses, :join_table => :done_statuses_for_project, :class_name => "Status"
 
       include InstanceMethods

--- a/lib/open_project/backlogs/patches/query_patch.rb
+++ b/lib/open_project/backlogs/patches/query_patch.rb
@@ -38,8 +38,6 @@ require_dependency 'query'
 module OpenProject::Backlogs::Patches::QueryPatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       include InstanceMethods
 
       add_available_column(QueryColumn.new(:story_points, :sortable => "#{WorkPackage.table_name}.story_points"))

--- a/lib/open_project/backlogs/patches/status_patch.rb
+++ b/lib/open_project/backlogs/patches/status_patch.rb
@@ -38,8 +38,6 @@ require_dependency 'status'
 module OpenProject::Backlogs::Patches::StatusPatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       include InstanceMethods
     end
   end

--- a/lib/open_project/backlogs/patches/type_patch.rb
+++ b/lib/open_project/backlogs/patches/type_patch.rb
@@ -38,8 +38,6 @@ require_dependency 'type'
 module OpenProject::Backlogs::Patches::TypePatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       include InstanceMethods
       extend ClassMethods
     end

--- a/lib/open_project/backlogs/patches/user_patch.rb
+++ b/lib/open_project/backlogs/patches/user_patch.rb
@@ -38,8 +38,6 @@ require_dependency 'user'
 module OpenProject::Backlogs::Patches::UserPatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       include InstanceMethods
     end
   end

--- a/lib/open_project/backlogs/patches/version_patch.rb
+++ b/lib/open_project/backlogs/patches/version_patch.rb
@@ -38,8 +38,6 @@ require_dependency 'version'
 module OpenProject::Backlogs::Patches::VersionPatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       has_many :version_settings, :dependent => :destroy
       accepts_nested_attributes_for :version_settings
 

--- a/lib/open_project/backlogs/patches/versions_controller_patch.rb
+++ b/lib/open_project/backlogs/patches/versions_controller_patch.rb
@@ -38,8 +38,6 @@ require_dependency 'versions_controller'
 module OpenProject::Backlogs::Patches::VersionsControllerPatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       include VersionSettingsHelper
       helper :version_settings
 

--- a/lib/open_project/backlogs/patches/work_package_patch.rb
+++ b/lib/open_project/backlogs/patches/work_package_patch.rb
@@ -38,8 +38,6 @@ require_dependency 'work_package'
 module OpenProject::Backlogs::Patches::WorkPackagePatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       include InstanceMethods
       extend ClassMethods
 

--- a/lib/open_project/backlogs/patches/work_package_schema_patch.rb
+++ b/lib/open_project/backlogs/patches/work_package_schema_patch.rb
@@ -38,8 +38,6 @@ require_dependency 'api/v3/work_packages/schema/work_package_schema'
 module OpenProject::Backlogs::Patches::WorkPackageSchemaPatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       include InstanceMethods
       extend ClassMethods
     end

--- a/lib/open_project/backlogs/patches/work_packages_helper_patch.rb
+++ b/lib/open_project/backlogs/patches/work_packages_helper_patch.rb
@@ -36,8 +36,6 @@
 module OpenProject::Backlogs::Patches::WorkPackagesHelperPatch
   def self.included(base)
     base.class_eval do
-      unloadable
-
       def work_package_form_all_middle_attributes_with_backlogs(form, work_package, locals = {})
         attributes = work_package_form_all_middle_attributes_without_backlogs(form, work_package, locals)
 


### PR DESCRIPTION
Relates to #138, but warrants extra review.

Rails 4 appears to change how dependency loading works: we hit a bunch of `Circular dependency detected while autoloading constant …` errors in development mode, e.g. when code is modified and Rails tries to reload the constant.

Other projects (e.g. https://github.com/thoughtbot/clearance/issues/276) seemed to have resolved the issue by removing `unloadable`

See also https://github.com/opf/openproject/pull/2104#issuecomment-112331283 for _the why_
