### PR TITLE
fix schema generation when no type is set

### DIFF
--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -178,7 +178,8 @@ module OpenProject::Backlogs
              type: 'Integer',
              required: false,
              show_if: -> (*) {
-               represented.project.backlogs_enabled? && represented.type.story?
+               represented.project.backlogs_enabled? &&
+                 (!represented.type || represented.type.story?)
              }
 
       schema :remaining_time,


### PR DESCRIPTION
will happen for an UntypedWorkPackageSchema, in the `project/:id/work_packages/columns` endpoint
