### PR TITLE
[21286] Wrong string shown in TaskBoard

### DIFF
--- a/app/assets/stylesheets/backlogs/taskboard.css.sass
+++ b/app/assets/stylesheets/backlogs/taskboard.css.sass
@@ -223,7 +223,8 @@
 
 .task_editor_dialog.ui-dialog
   .ui-dialog-titlebar-close
-    display: none
+    .ui-button-text
+      display: none
   .ui-widget-header
     background: none
     background-color: #FFFFFF


### PR DESCRIPTION
The titlebar is shown again, except the text of the close-button.

https://community.openproject.org/work_packages/21286
