### PR TITLE
[21433] wrong font color in Taskboards

### DIFF
--- a/app/assets/stylesheets/backlogs/taskboard.css.sass
+++ b/app/assets/stylesheets/backlogs/taskboard.css.sass
@@ -233,9 +233,12 @@
   .ui-dialog-title
     float: right
     margin-right: 0
+    color: $body-font-color
   &.ui-widget-content
     background: none
     border: none
+    .editor
+      color: $body-font-color
   .ui-dialog-buttonpane.ui-widget-content
     background: none
     background-color: none


### PR DESCRIPTION
This sets the body font color for the headline and the fields when adding a new Task in Taskboards.

https://community.openproject.org/work_packages/21433
