### PR TITLE
[21477] Toolbar label not correctly displayed

### DIFF
--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -41,10 +41,10 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= toolbar title: h(@sprint.name) do %>
   <% if @sprint.has_burndown? %>
-    <li class="toolbar-item">
-      <label for="col_width_input"><%= l('backlogs.column_width') %></label>
-    </li>
-    <li class="toolbar-item" id="col_width">
+    <li class="toolbar-item toolbar-input-group" id="col_width">
+      <div>
+        <label for="col_width_input"><%= l('backlogs.column_width') %></label>
+      </div>
       <input type="text" id="col_width_input">
     </li>
     <li class="toolbar-item">


### PR DESCRIPTION
This changes the DOM-structure and thus uses correctly the toolbar-element.

https://community.openproject.org/work_packages/21477
