### PR TITLE
[21496] Wrong layout for the Burndown Chart

### DIFF
--- a/app/helpers/burndown_charts_helper.rb
+++ b/app/helpers/burndown_charts_helper.rb
@@ -51,8 +51,18 @@ module BurndownChartsHelper
   end
 
   def xaxis_labels(burndown)
-    burndown.days.enum_for(:each_with_index).map { |d, i| "[#{i + 1}, '#{escape_javascript(::I18n.t('date.abbr_day_names')[d.wday % 7])}']" }.join(',').html_safe +
-      ", [#{burndown.days.length + 1}, '<span class=\"axislabel\">#{I18n.t('backlogs.date')}</span>']".html_safe
+    # 14 entries (plus the axis label) have come along as the best value for a good optical result.
+    # Thus it is enough space between the entries.
+    entries_displayed = (burndown.days.length / 14.0).ceil
+    burndown.days.enum_for(:each_with_index).map do |d, i|
+      if ((i % entries_displayed) == 0)
+        "[#{i + 1},
+         '#{escape_javascript(::I18n.t('date.abbr_day_names')[d.wday % 7])}
+         #{d.strftime('%d/%m')}']"
+      end
+    end.join(',').html_safe +
+      ", [#{burndown.days.length + 1},
+       '<span class=\"axislabel\">#{I18n.t('backlogs.date')}</span>']".html_safe
   end
 
   def dataseries(burndown)

--- a/app/views/rb_burndown_charts/_burndown.html.erb
+++ b/app/views/rb_burndown_charts/_burndown.html.erb
@@ -47,7 +47,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
         $.each(Burndown.datasets, function (key, val) {
           val.color = i;
-          val.points = {show: true, radius: 2};
+          val.points = {show: false, radius: 2};
           val.lines = {show: true};
           ++i;
         });
@@ -77,7 +77,7 @@ See doc/COPYRIGHT.rdoc for more details.
             yaxis: { min: 0,
               ticks: [ <%= yaxis_labels(burndown) %> ] },
             xaxis: {
-              ticks: [<%= xaxis_labels(burndown) %>],
+              ticks: [ <%= xaxis_labels(burndown) %> ],
               tickDecimals: 0,
               max: <%= burndown.days.length + 1 %>,
               min: 1


### PR DESCRIPTION
This changes the layout of the x-axis of the burndown graph. There is only a limited number of entries shown and the date is added to the day. Further the bullets were removed from the graph.

https://community.openproject.org/work_packages/21496/activity
