### PR TITLE
quickfix for moving impediments

### DIFF
--- a/app/models/impediment.rb
+++ b/app/models/impediment.rb
@@ -60,6 +60,15 @@ class Impediment < Task
     @blocks_ids_list ||= relations_from.select { |rel| rel.relation_type == Relation::TYPE_BLOCKS }.map(&:to_id)
   end
 
+  def self.create_with_relationships(params, project_id)
+    create_with_relationships_without_move(params, project_id)
+  end
+
+
+  def update_with_relationships(params, _is_impediment = false)
+    update_with_relationships_without_move(params)
+  end
+
   private
 
   def update_blocks_list


### PR DESCRIPTION
Impediments are not grouped by a root_id. As such they can not be sorted currently. The commit fixes the error being caused. It however does not disable to possibility to move an impediment within a taskboard table cell (e.g. from after another impediment to before it). Those changes will be lost after a reload.
