### PR TITLE
Fix version for Rails compatibility

### DIFF
--- a/openproject-backlogs.gemspec
+++ b/openproject-backlogs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", "~> 3.2.9"
-  s.add_dependency "acts_as_silent_list"
+  s.add_dependency "acts_as_silent_list", "~> 1.3.0"
   
   s.add_dependency "openproject-pdf_export"
 


### PR DESCRIPTION
With Rails 4.2 features landing on the master branch
in 6b426e8, we need to restrict the version on release/4.2

Bug report: https://community.openproject.org/work_packages/21647
