### PR TITLE
[21955] Buttons too close on tables (Backlogs)

### DIFF
--- a/app/views/projects/settings/_backlogs_settings.html.erb
+++ b/app/views/projects/settings/_backlogs_settings.html.erb
@@ -79,8 +79,10 @@ See doc/COPYRIGHT.rdoc for more details.
     <div class="generic-table--header-background"></div>
   </div>
 </div>
+<div class="generic-table--action-buttons">
+  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+</div>
 
-<p><%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %></p>
 <% end %>
 
 <h3><%=l('backlogs.rebuild_positions')%></h3>

--- a/app/views/projects/settings/_versions.html.erb
+++ b/app/views/projects/settings/_versions.html.erb
@@ -146,6 +146,12 @@ See doc/COPYRIGHT.rdoc for more details.
       <div class="generic-table--header-background"></div>
     </div>
   </div>
+  <div class="generic-table--action-buttons">
+        <%= link_to_if_authorized({:controller => '/versions', :action => 'new', :project_id => @project}, class: 'button -alt-highlight') do %>
+          <i class="button--icon icon-add"></i>
+          <span class="button--text"><%= l(:label_version_new) %></span>
+        <% end %>
+  </div>
 <% else %>
   <div class="generic-table--container">
     <div class="generic-table--no-results-container">
@@ -166,4 +172,3 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 </div>
 
-<p><%= link_to_if_authorized l(:label_version_new), :controller => '/versions', :action => 'new', :project_id => @project %></p>


### PR DESCRIPTION
This applies the class 'generic-table--action-buttons' for the backlogs plugin. Thus it is strongly related to https://github.com/opf/openproject/pull/3756 .

https://community.openproject.org/work_packages/21955/activity
