### PR TITLE
Define as default module

### DIFF
--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -49,4 +49,6 @@ else
       story_types: story_types,
       task_type: task_type
   }.with_indifferent_access
+
+  Setting.default_projects_modules += ['backlogs']
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/22020/activity

Testing this might be hard because the check if settings should be seeded is too strict. It checks if there already is a setting for plugin and there always will be: because of a migration. So we maybe should fix that, too.
