### PR TITLE
[22037] Apply new icon styling (Backlogs)

### DIFF
--- a/app/assets/javascripts/backlogs/model.js
+++ b/app/assets/javascripts/backlogs/model.js
@@ -379,7 +379,7 @@ RB.Model = (function ($) {
     },
 
     markError: function () {
-      this.$.addClass('error icon icon-error');
+      this.$.addClass('error icon icon-bug');
     },
 
     markIfClosed: function () {
@@ -487,7 +487,7 @@ RB.Model = (function ($) {
     },
 
     unmarkError: function () {
-      this.$.removeClass('error icon icon-error');
+      this.$.removeClass('error icon icon-bug');
     },
 
     unmarkSaving: function () {

--- a/app/assets/stylesheets/backlogs/master_backlog.css.sass
+++ b/app/assets/stylesheets/backlogs/master_backlog.css.sass
@@ -163,7 +163,7 @@
           background-image: image-url("loading.gif")
           background-repeat: no-repeat
           background-position: center
-        &.error.icon-error
+        &.error.icon-bug
           background: none
           text-align: center
           &:before
@@ -211,7 +211,7 @@
         background-image: image-url("loading.gif")
         background-repeat: no-repeat
         background-position: center
-      &.error.icon-error
+      &.error.icon-bug
         background: none
         text-align: center
         &:before

--- a/app/assets/stylesheets/backlogs/taskboard.css.sass
+++ b/app/assets/stylesheets/backlogs/taskboard.css.sass
@@ -200,7 +200,7 @@
       background: none
       border: none
 
-    &.error.icon-error:before
+    &.error.icon-bug:before
       position: absolute
       top: 30px
       left: 28px

--- a/app/views/projects/settings/_backlogs_settings.html.erb
+++ b/app/views/projects/settings/_backlogs_settings.html.erb
@@ -80,7 +80,7 @@ See doc/COPYRIGHT.rdoc for more details.
   </div>
 </div>
 <div class="generic-table--action-buttons">
-  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 </div>
 
 <% end %>

--- a/app/views/version_settings/edit.html.erb
+++ b/app/views/version_settings/edit.html.erb
@@ -37,5 +37,5 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% labelled_tabular_form_for :version, @version, :url => project_version_path(@project, @version), :html => {:method => :put} do |f| %>
 <%= render :partial => 'form', :locals => { :f => f } %>
-<%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-yes' %>
+<%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
 <% end %>

--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -107,7 +107,7 @@ module OpenProject::Backlogs
            before: :calendar,
            param: :project_id,
            if: proc { not(User.current.respond_to?(:impaired?) and User.current.impaired?) },
-           html: { class: 'icon2 icon-backlogs-icon' }
+           html: { class: 'icon2 icon-backlogs' }
     end
 
     assets %w(


### PR DESCRIPTION
This applies the new icon styling in the plugin. Note that this only works in combination with https://github.com/opf/openproject/pull/3873 since there the icon font is updated.

https://community.openproject.org/work_packages/22037/activity
