### PR TITLE
Require Core in own version

### DIFF
--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -53,7 +53,7 @@ module OpenProject::Backlogs
 
     register 'openproject-backlogs',
              author_url: 'http://finn.de',
-             requires_openproject: '>= 4.0.0',
+             requires_openproject: "= #{OpenProject::Backlogs::VERSION}",
              settings: settings do
       Redmine::AccessControl.permission(:edit_project).actions << 'projects/project_done_statuses'
       Redmine::AccessControl.permission(:edit_project).actions << 'projects/rebuild_positions'


### PR DESCRIPTION
We lockstep our version in core and plugins. We should apply this here as well. 
