### PR TITLE
Require version.rb

### DIFF
--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -34,6 +34,7 @@
 #++
 
 require 'open_project/plugins'
+require 'open_project/backlogs/version'
 
 require 'acts_as_silent_list'
 


### PR DESCRIPTION
Locally it works without because we `require` the `version.rb` in the `gemspec`. But when bundler takes a gem from git it [rewrites the `gemspec`](https://github.com/bundler/bundler/blob/80cf688bab7ee3ced619c12ac5e2d6dfb0c78c38/lib/bundler/source/git.rb#L234)
