### PR TITLE
[22264] Missing icon in backlogs master view

### DIFF
--- a/app/assets/stylesheets/backlogs/master_backlog.css.sass
+++ b/app/assets/stylesheets/backlogs/master_backlog.css.sass
@@ -143,11 +143,11 @@
           width: 23px
           cursor: pointer
           &:before
-            content: "\e0d4"
-            margin-left: 5px
+            content: "\e08a"
+            margin-left: 7px
           &.closed:before
-            content: "\e0d2"
-            margin-left: 5px
+            content: "\e089"
+            margin-left: 7px
           &:hover
             cursor: pointer
             background-color: #D8D8D8

--- a/app/views/rb_master_backlogs/_backlog.html.erb
+++ b/app/views/rb_master_backlogs/_backlog.html.erb
@@ -40,7 +40,7 @@ See doc/COPYRIGHT.rdoc for more details.
     <%= render_backlog_menu backlog %>
     <%= render :partial => "rb_sprints/sprint", :object => backlog.sprint %>
     <div class="velocity"> </div>
-    <div class="toggler<%= ' closed' if folded %>"> </div>
+    <div class="toggler<%= ' closed' if folded %> icon-small"> </div>
   </div>
   <ul class="stories<%= ' closed' if folded %>">
     <% reset_cycle 'stories' %>


### PR DESCRIPTION
This updates the used icon codes for the new icon font.

https://community.openproject.org/work_packages/22264/activity
