### PR TITLE
[22335] Missing 'Add-all' functionality in backlogs settings

### DIFF
--- a/app/views/projects/settings/_backlogs_settings.html.erb
+++ b/app/views/projects/settings/_backlogs_settings.html.erb
@@ -26,62 +26,69 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title:l('backlogs.definition_of_done')  %>
 
 <% statuses_done_for_project = @project.done_statuses.select(:id).map(&:id) %>
 
-<%= styled_form_tag(:controller => '/projects', :action => "project_done_statuses", :id => @project) do %>
+<%= styled_form_tag(controller: '/projects', action: "project_done_statuses", id: @project) do %>
 
-<div class="generic-table--container">
-  <div class="generic-table--results-container">
-    <table interactive-table role="grid" class="generic-table" id="material_budget_items">
-      <colgroup>
-        <col highlight-col>
-        <col highlight-col>
-      </colgroup>
-      <thead>
-        <tr>
-          <th>
-            <div class="generic-table--sort-header-outer">
-              <div class="generic-table--sort-header">
-                <span>
-                  <%= Status.model_name.human %>
-                </span>
-              </div>
-            </div>
-          </th>
-          <th>
-            <div class="generic-table--sort-header-outer">
-              <div class="generic-table--sort-header">
-                <span>
-                  <%=l('backlogs.work_package_is_closed')%>
-                </span>
-              </div>
-            </div>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <% for status in @statuses %>
-          <tr>
-            <td>
-              <%= status.name %>
-            </td>
-            <td style="text-align:left">
-              <% checkbox_id = status.name.parameterize.underscore %>
-              <%= styled_label_tag checkbox_id, l('backlogs.label_is_done_status', status_name: status.name), class: 'hidden-for-sighted' %>
-              <%= (styled_check_box_tag 'statuses[][status_id]', status.id.to_s, statuses_done_for_project.include?(status.id), id: checkbox_id) %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-    <div class="generic-table--header-background"></div>
+<fieldset class="form--fieldset" id="form--backlogs">
+  <legend class="form--fieldset-legend"><%=l('backlogs.definition_of_done')%></legend>
+  <div class="form--fieldset-control">
+    <span class="form--fieldset-control-container">
+      (<%= check_all_links 'form--backlogs' %>)
+    </span>
   </div>
-</div>
-<div class="generic-table--action-buttons">
-  <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
-</div>
+  <div class="generic-table--container">
+    <div class="generic-table--results-container">
+      <table interactive-table role="grid" class="generic-table" id="material_budget_items">
+        <colgroup>
+          <col highlight-col>
+          <col highlight-col>
+        </colgroup>
+        <thead>
+          <tr>
+            <th>
+              <div class="generic-table--sort-header-outer">
+                <div class="generic-table--sort-header">
+                  <span>
+                    <%= Status.model_name.human %>
+                  </span>
+                </div>
+              </div>
+            </th>
+            <th>
+              <div class="generic-table--sort-header-outer">
+                <div class="generic-table--sort-header">
+                  <span>
+                    <%=l('backlogs.work_package_is_closed')%>
+                  </span>
+                </div>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <% for status in @statuses %>
+            <tr>
+              <td>
+                <%= status.name %>
+              </td>
+              <td style="text-align:left">
+                <% checkbox_id = status.name.parameterize.underscore %>
+                <%= styled_label_tag checkbox_id, l('backlogs.label_is_done_status', status_name: status.name), class: 'hidden-for-sighted' %>
+                <%= (styled_check_box_tag 'statuses[][status_id]', status.id.to_s, statuses_done_for_project.include?(status.id), id: checkbox_id) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <div class="generic-table--header-background"></div>
+    </div>
+  </div>
+  <div class="generic-table--action-buttons">
+    <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>
+  </div>
+</fieldset>
 
 <% end %>
 


### PR DESCRIPTION
This adds the 'check-All' funtionality to backlogs settings and uses a fields for the desired styling.

https://community.openproject.org/work_packages/22335/activity
