### PR TITLE
[22297] Option to adjust column width only shown when burndown chart option is available (start and end date set)

### DIFF
--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -40,13 +40,13 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <%= toolbar title: @sprint.name do %>
+  <li class="toolbar-item toolbar-input-group" id="col_width">
+    <div>
+      <label for="col_width_input"><%= l('backlogs.column_width') %></label>
+    </div>
+    <input type="text" id="col_width_input">
+  </li>
   <% if @sprint.has_burndown? %>
-    <li class="toolbar-item toolbar-input-group" id="col_width">
-      <div>
-        <label for="col_width_input"><%= l('backlogs.column_width') %></label>
-      </div>
-      <input type="text" id="col_width_input">
-    </li>
     <li class="toolbar-item">
       <%= show_burndown_link(@sprint) %>
     </li>


### PR DESCRIPTION
This shows the adjustment of columns independent of the start and end day of a version.

https://community.openproject.org/work_packages/22297/activity
