### PR TITLE
[22837] Backlogs context menu only shown / hidden on click

### DIFF
--- a/app/helpers/rb_master_backlogs_helper.rb
+++ b/app/helpers/rb_master_backlogs_helper.rb
@@ -37,9 +37,9 @@ module RbMasterBacklogsHelper
   include Redmine::I18n
 
   def render_backlog_menu(backlog)
-    content_tag(:div, class: 'menu') do
+    content_tag(:div, class: 'menu', onmouseleave: "if(this.firstChild.classList.contains('open')) this.firstChild.classList.remove('open');") do
       [
-        content_tag(:div, '', class: "icon-context icon-small", onClick: "if(this.classList.contains('open')) this.classList.remove('open'); else this.classList.add('open');"),
+        content_tag(:div, '', class: "icon-context icon-small", onmouseover: "if(this.classList.contains('open')) this.classList.remove('open'); else this.classList.add('open');"),
         content_tag(:ul, class: 'items') do
           backlog_menu_items_for(backlog).map { |item|
             content_tag(:li, item, class: 'item')


### PR DESCRIPTION
This changes the dropdown menu in backlogs from a click event to a mouseOver event. This the menu hides one the mouse is left or something is clicked.
