### PR TITLE
[20432] [Accessibility] Some form elements are pronounced with a wrong label (Backlogs)

### DIFF
--- a/app/views/shared/_view_my_settings.html.erb
+++ b/app/views/shared/_view_my_settings.html.erb
@@ -34,12 +34,14 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<h3 class="form--section-title"><%=l(:label_backlogs)%></h3>
-<div class="form--field">
-  <%= styled_label_tag :backlogs_task_color, l(:'backlogs.task_color') %>
-  <%= styled_text_field_tag :'backlogs[task_color]', color, container_class: '-middle' %>
-</div>
-<div class="form--field">
-  <%= styled_label_tag :backlogs_versions_default_fold_state, I18n.t('backlogs.label_versions_default_fold_state') %>
-  <%= styled_check_box_tag :"backlogs[versions_default_fold_state]", "closed", versions_default_fold_state == "closed" %>
-</div>
+<fieldset class="form--fieldset">
+  <legend class="form--fieldset-legend"><%=l(:label_backlogs)%></legend>
+  <div class="form--field">
+    <%= styled_label_tag :backlogs_task_color, l(:'backlogs.task_color') %>
+    <%= styled_text_field_tag :'backlogs[task_color]', color, container_class: '-middle' %>
+  </div>
+  <div class="form--field">
+    <%= styled_label_tag :backlogs_versions_default_fold_state, I18n.t('backlogs.label_versions_default_fold_state') %>
+    <%= styled_check_box_tag :"backlogs[versions_default_fold_state]", "closed", versions_default_fold_state == "closed" %>
+  </div>
+</fieldset>


### PR DESCRIPTION
In https://github.com/opf/openproject/pull/4283 there are fieldsets introduced in MyAccount/settings for a better accessibility with screenreaders. This PR changes this for the backlogs part.

https://community.openproject.com/work_packages/20432/activity
