### PR TITLE
[20524] [Accessibility] Some pages do not have their own window title (Backlogs)

### DIFF
--- a/app/views/rb_export_card_configurations/index.html.erb
+++ b/app/views/rb_export_card_configurations/index.html.erb
@@ -37,7 +37,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <div class='contextual'></div>
 <%= toolbar title: l(:label_backlogs_export_card_config_select) %>
-
+<% html_title l(:label_backlogs_export_card_config_select) %>
 <ul>
 <% @configs.each do |config| %>
   <li>

--- a/app/views/rb_master_backlogs/index.html.erb
+++ b/app/views/rb_master_backlogs/index.html.erb
@@ -40,6 +40,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <div class='contextual'></div>
+<% html_title l(:label_backlogs) %>
 <%= toolbar title: l(:label_backlogs) %>
 
 <div id="rb">

--- a/app/views/rb_taskboards/show.html.erb
+++ b/app/views/rb_taskboards/show.html.erb
@@ -38,7 +38,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <%= render :partial => 'shared/backlogs_header' %>
   <%= stylesheet_link_tag 'backlogs/taskboard.css' %>
 <% end %>
-
+<%= html_title @sprint.name do %>
 <%= toolbar title: @sprint.name do %>
   <li class="toolbar-item toolbar-input-group" id="col_width">
     <div>

--- a/app/views/shared/_settings.html.erb
+++ b/app/views/shared/_settings.html.erb
@@ -66,7 +66,7 @@ See doc/COPYRIGHT.rdoc for more details.
     });
   </script>
 <% end %>
-
+<% html_title l(:label_administration), l(:label_plugins), 'Backlogs' %>
 <div class="form--field">
   <%= styled_label_tag("settings[story_types]", l(:backlogs_story_type)) %>
   <%= styled_select_tag("settings[story_types]",

--- a/app/views/version_settings/edit.html.erb
+++ b/app/views/version_settings/edit.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= toolbar title: l(:label_version)  %>
-
+<% html_title l(:label_version) %>
 <% labelled_tabular_form_for :version, @version, :url => project_version_path(@project, @version), :html => {:method => :put} do |f| %>
 <%= render :partial => 'form', :locals => { :f => f } %>
 <%= styled_button_tag l(:button_save), class: '-highlight -with-icon icon-checkmark' %>


### PR DESCRIPTION
This inserts concrete html title attributes for some pages. Thus it is easier for blind users to navigate through the application.

https://community.openproject.com/work_packages/20524/activity
