### PR TITLE
alter representer cache key based on whether backlogs  is activated

### DIFF
--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -197,6 +197,14 @@ module OpenProject::Backlogs
       end
     end
 
+    add_api_representer_cache_key(:v3, :work_packages, :schema, :work_package_schema) do
+      if represented.project.module_enabled?('backlogs')
+        ['backlogs_enabled']
+      else
+        ['backlogs_not_enabled']
+      end
+    end
+
     initializer 'backlogs.register_hooks' do
       require 'open_project/backlogs/hooks'
     end

--- a/spec/api/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/api/work_packages/work_package_schema_representer_spec.rb
@@ -129,4 +129,29 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
       end
     end
   end
+
+  describe '#cache_key' do
+    def joined_cache_key
+      representer.cache_key.join('/')
+    end
+
+    before do
+      allow(work_package.project)
+        .to receive(:module_enabled?)
+        .and_return false
+
+      original_cache_key
+    end
+
+    let(:original_cache_key) { joined_cache_key }
+
+    it 'changes depending on whether costs is enabled or not' do
+      allow(work_package.project)
+        .to receive(:module_enabled?)
+        .with('backlogs')
+        .and_return true
+
+      expect(joined_cache_key).to_not eql(original_cache_key)
+    end
+  end
 end


### PR DESCRIPTION
Extends the WP schema cache key with the information of whether the backlogs plugin is active in the project.

Belongs to https://github.com/opf/openproject/pull/4385
