### PR TITLE
[23253] Burndown chart broken, caused by localisation

### DIFF
--- a/app/helpers/burndown_charts_helper.rb
+++ b/app/helpers/burndown_charts_helper.rb
@@ -64,7 +64,7 @@ module BurndownChartsHelper
   end
 
   def dataseries(burndown)
-    burndown.series.map { |s| "#{s.first}: {label: '#{l('backlogs.' + s.first.to_s)}', data: [#{s.last.enum_for(:each_with_index).map { |s, i| "[#{i + 1}, #{s}] " }.join(', ')}]} " }.join(', ').html_safe
+    burndown.series.map { |s| "#{s.first}: {label: '#{l('backlogs.' + %q[s.first.to_s].html_safe)}', data: [#{s.last.enum_for(:each_with_index).map { |s, i| "[#{i + 1}, #{s}] " }.join(', ')}]} " }.join(', ').html_safe
   end
 
   def burndown_series_checkboxes(burndown)


### PR DESCRIPTION
This escapes the quotes of a label. In french there are quotes in the label causing the burn down graph to crash.

https://community.openproject.com/work_packages/23253/activity
