### PR TITLE
Don't output JSON manually

### DIFF
--- a/app/helpers/burndown_charts_helper.rb
+++ b/app/helpers/burndown_charts_helper.rb
@@ -64,7 +64,15 @@ module BurndownChartsHelper
   end
 
   def dataseries(burndown)
-    burndown.series.map { |s| "#{s.first}: {label: '#{l('backlogs.' + s.first.to_s)}', data: [#{s.last.enum_for(:each_with_index).map { |s, i| "[#{i + 1}, #{s}] " }.join(', ')}]} " }.join(', ').html_safe
+    dataset = {}
+    burndown.series.each do |s|
+      dataset[s.first] = {
+        label: l('backlogs.' + s.first.to_s),
+        data: s.last.enum_for(:each_with_index).map { |val, i| [i + 1, val] }
+      }
+    end
+
+    dataset
   end
 
   def burndown_series_checkboxes(burndown)

--- a/app/views/rb_burndown_charts/_burndown.html.erb
+++ b/app/views/rb_burndown_charts/_burndown.html.erb
@@ -39,7 +39,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <script type="text/javascript" language="javascript">
   jQuery(function ($) {
     var Burndown = {
-      datasets: { <%= dataseries(burndown) %> },
+      datasets: <%= dataseries(burndown).to_json.html_safe %> ,
       previousPoint: null,
 
       setDatasetColor: function () {

--- a/app/views/shared/_server_variables.js.erb
+++ b/app/views/shared/_server_variables.js.erb
@@ -40,8 +40,8 @@ RB.constants = {
 };
 
 RB.i18n = {
-  generating_graph: '<%= l("backlogs.generating_chart") %>',
-  burndown_graph: '<%= l("backlogs.burndown_graph") %>'
+  generating_graph: '<%= j l("backlogs.generating_chart").html_safe %>',
+  burndown_graph: '<%= j l("backlogs.burndown_graph").html_safe %>'
 };
 
 RB.urlFor = (function () {


### PR DESCRIPTION
The burndown chart was rendered to json manually in the helper...

Supersedes https://github.com/finnlabs/openproject-backlogs/pull/222
https://community.openproject.com/work_packages/23253/activity
