### PR TITLE
[23980] Add buttons are not consistently used (Backlogs)

### DIFF
--- a/app/views/projects/settings/_versions.html.erb
+++ b/app/views/projects/settings/_versions.html.erb
@@ -156,9 +156,11 @@ See doc/COPYRIGHT.rdoc for more details.
     </div>
     <div class="generic-table--action-buttons">
       <%= link_to_if_authorized({ controller: '/versions', action: 'new', project_id: @project },
-                            class: 'button -alt-highlight') do %>
+                            { class: 'button -alt-highlight',
+                              aria: {label: t(:label_version_new)},
+                              title: t(:label_version_new)}) do %>
         <i class="button--icon icon-add"></i>
-        <span class="button--text"><%= l(:label_version_new) %></span>
+        <span class="button--text"><%= l(:label_version) %></span>
       <% end %>
     </div>
   <% else %>


### PR DESCRIPTION
The makes the use of 'add' buttons consistent.

https://community.openproject.com/work_packages/23980/activity

Related PRs:
- https://github.com/finnlabs/openproject-my_project_page/pull/83
- https://github.com/opf/openproject-documents/pull/64
- https://github.com/finnlabs/openproject-global_roles/pull/64
- https://github.com/finnlabs/openproject-meeting/pull/133
- https://github.com/finnlabs/openproject-pdf_export/pull/53
- https://github.com/opf/openproject/pull/4879
