### PR TITLE
[23994] Story points not clickable in version overview

### DIFF
--- a/app/assets/stylesheets/backlogs/master_backlog.css.sass
+++ b/app/assets/stylesheets/backlogs/master_backlog.css.sass
@@ -256,10 +256,10 @@
         width: 68px
       .story_points
         float: right
-        padding: 5px 3px 4px 2px
-        margin-right: 2.1em
-        width: 28px
+        padding: 5px 1rem 4px 2px
+        width: 3.5rem
         min-height: 14px
+        height: 2rem
         text-align: right
       .type_id .v, .id .v, .status_id .v, .fixed_version_id, .higher_item_id
         display: none


### PR DESCRIPTION
When the story points field is empty it is not really clickable since it is rather small. This PR increases the field so that is possible to enter edit mode here too.

https://community.openproject.com/work_packages/23994/activity
