### PR TITLE
[24226] Unnecessary line in burndown graph legend

### DIFF
--- a/app/assets/stylesheets/backlogs/master_backlog.css.sass
+++ b/app/assets/stylesheets/backlogs/master_backlog.css.sass
@@ -276,7 +276,6 @@
     fieldset.burndown_control
       padding-left: 10px
       border: none
-      border-top: 1px solid #BBB
     .axislabel
       font-weight: bold
 


### PR DESCRIPTION
This removes the top-border form the burndown chart legend. This is unnecessary since the fieldset legend already has a border itself.

https://community.openproject.com/work_packages/24226/activity