### PR TITLE
Fix/position in api

### DIFF
--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -203,14 +203,6 @@ module OpenProject::Backlogs
     end
 
     extend_api_response(:v3, :work_packages, :schema, :work_package_sums_schema) do
-      schema :position,
-             type: 'Integer',
-             required: false,
-             writable: false,
-             show_if: -> (*) {
-               ::Setting.work_package_list_summable_columns.include?('position')
-             }
-
       schema :story_points,
              type: 'Integer',
              required: false,
@@ -229,12 +221,6 @@ module OpenProject::Backlogs
     end
 
     extend_api_response(:v3, :work_packages, :work_package_sums) do
-      property :position,
-               render_nil: true,
-               if: -> (*) {
-                 ::Setting.work_package_list_summable_columns.include?('position')
-               }
-
       property :story_points,
                render_nil: true,
                if: -> (*) {

--- a/lib/open_project/backlogs/engine.rb
+++ b/lib/open_project/backlogs/engine.rb
@@ -157,10 +157,6 @@ module OpenProject::Backlogs
     end
 
     extend_api_response(:v3, :work_packages, :work_package_payload) do
-      property :position,
-               render_nil: true,
-               if: ->(*) { backlogs_enabled? && type && type.passes_attribute_constraint?(:position) }
-
       property :story_points,
                render_nil: true,
                if: ->(*) { backlogs_enabled? && type && type.passes_attribute_constraint?(:story_points) }


### PR DESCRIPTION
Removes the `position` property from
* the wp payload. As a read only property, it mustn't be listed there. Fixes https://community.openproject.com/projects/openproject/work_packages/25458
* the wp sums schema. Position is not summable.