### PR TITLE
Add line-through to closed stories

### DIFF
--- a/app/assets/stylesheets/backlogs/master_backlog.sass
+++ b/app/assets/stylesheets/backlogs/master_backlog.sass
@@ -221,6 +221,8 @@
           pointer-events: none
       &.hover, &:hover
         background-color: rgb(254, 248, 168)
+      &.closed
+        text-decoration: line-through
       .id
         float: left
         margin-left: 1em


### PR DESCRIPTION
We just migrated from Redmine and customers are complaining that closed stories aren't striked out. 