### PR TITLE
Add horizontal scroll to taskboard when needed

### DIFF
--- a/app/assets/stylesheets/backlogs/taskboard.sass
+++ b/app/assets/stylesheets/backlogs/taskboard.sass
@@ -61,6 +61,7 @@
   white-space: inherit
 
 #rb
+  overflow-x: auto
   #assigned_to_id_options
     display: none
   .swimlane


### PR DESCRIPTION
This is needed when you have five or more columns and the  column width is
set to a value where content is bigger than the screen width and no horizontal scroll was shown.