### PR TITLE
don't use inline js to adhere to csp

### DIFF
--- a/app/assets/javascripts/backlogs/taskboard.js
+++ b/app/assets/javascripts/backlogs/taskboard.js
@@ -66,6 +66,8 @@ RB.Taskboard = (function ($) {
 
       this.initializeNewButtons();
       this.initializeSortables();
+
+      this.initializeTaskboardMenus();
     },
 
     initializeNewButtons : function () {
@@ -114,6 +116,18 @@ RB.Taskboard = (function ($) {
     initializeImpediments : function () {
       this.$.find('.impediment').each(function (index) {
         RB.Factory.initialize(RB.Impediment, this);
+      });
+    },
+
+    initializeTaskboardMenus : function () {
+      var toggleOpen = "open icon-pulldown-up icon-pulldown";
+
+      $(".backlog .menu > div.menu-trigger").on("click", function() {
+        $(this).toggleClass(toggleOpen);
+      });
+
+      $(".backlog .menu > ul.items li.item").on("click", function() {
+        $(this).closest(".menu").find("div.menu-trigger").toggleClass(toggleOpen);
       });
     },
 

--- a/app/helpers/rb_master_backlogs_helper.rb
+++ b/app/helpers/rb_master_backlogs_helper.rb
@@ -37,15 +37,13 @@ module RbMasterBacklogsHelper
   include Redmine::I18n
 
   def render_backlog_menu(backlog)
-    closeJS = "jQuery(this).closest('ul').siblings('.menu-trigger').toggleClass('open icon-pulldown-up icon-pulldown');"
-    openJS = "jQuery(this).toggleClass('open icon-pulldown-up icon-pulldown');"
-
+    # associated javascript defined in taskboard.js
     content_tag(:div, class: 'menu') do
       [
-        content_tag(:div, '', class: "menu-trigger icon-context icon-pulldown icon-small", onClick: openJS),
+        content_tag(:div, '', class: "menu-trigger icon-context icon-pulldown icon-small"),
         content_tag(:ul, class: 'items') do
           backlog_menu_items_for(backlog).map { |item|
-            content_tag(:li, item, class: 'item', onClick: closeJS)
+            content_tag(:li, item, class: 'item')
           }.join.html_safe
         end
       ].join.html_safe


### PR DESCRIPTION
Backlogs menus don't work due to inline javascript blocked by our CSP.
This fixes that.

![image](https://user-images.githubusercontent.com/158871/42562041-9bbf6e8e-84f2-11e8-8f3c-bddb995bfe7c.png)
