### PR TITLE
[27586] Guided tour for user onboarding (Backlogs)

### DIFF
--- a/app/assets/javascripts/backlogs/burndown.js
+++ b/app/assets/javascripts/backlogs/burndown.js
@@ -63,8 +63,13 @@ RB.Burndown = (function ($) {
       }
       $('#charts').html("<div class='loading'>" + RB.i18n.generating_graph + "</div>");
 
-      var url = RB.urlFor('show_burndown_chart', { sprint_id: $(this).data('this').sprintId, project_id: RB.constants.project_id});
-      window.open(url);
+      var url = RB.urlFor('show_burndown_chart', {
+          sprint_id: $(this).data('this').sprintId,
+          project_id: RB.constants.project_id
+      });
+      
+      var burndownWindow = window.open(url);
+      burndownWindow.sessionStorage.clear();
     }
   });
 }(jQuery));

--- a/app/assets/javascripts/backlogs/burndown.js
+++ b/app/assets/javascripts/backlogs/burndown.js
@@ -63,13 +63,8 @@ RB.Burndown = (function ($) {
       }
       $('#charts').html("<div class='loading'>" + RB.i18n.generating_graph + "</div>");
 
-      var url = RB.urlFor('show_burndown_chart', {
-          sprint_id: $(this).data('this').sprintId,
-          project_id: RB.constants.project_id
-      });
-      
-      var burndownWindow = window.open(url);
-      burndownWindow.sessionStorage.clear();
+      var url = RB.urlFor('show_burndown_chart', { sprint_id: $(this).data('this').sprintId, project_id: RB.constants.project_id});
+      window.open(url);
     }
   });
 }(jQuery));

--- a/app/helpers/rb_master_backlogs_helper.rb
+++ b/app/helpers/rb_master_backlogs_helper.rb
@@ -122,10 +122,10 @@ module RbMasterBacklogsHelper
     items = {}
 
     items[:task_board] = link_to(l(:label_task_board),
-                                 {controller: '/rb_taskboards',
-                                 action: 'show',
-                                 project_id: @project,
-                                 sprint_id: backlog.sprint},
+                                 { controller: '/rb_taskboards',
+                                   action: 'show',
+                                   project_id: @project,
+                                   sprint_id: backlog.sprint },
                                  class: 'show_task_board')
 
 

--- a/app/helpers/rb_master_backlogs_helper.rb
+++ b/app/helpers/rb_master_backlogs_helper.rb
@@ -122,10 +122,12 @@ module RbMasterBacklogsHelper
     items = {}
 
     items[:task_board] = link_to(l(:label_task_board),
-                                 controller: '/rb_taskboards',
+                                 {controller: '/rb_taskboards',
                                  action: 'show',
                                  project_id: @project,
-                                 sprint_id: backlog.sprint)
+                                 sprint_id: backlog.sprint},
+                                 class: 'show_task_board')
+
 
     if backlog.sprint.has_burndown?
       items[:burndown] = content_tag(:a,

--- a/spec/features/onboarding/backogs_onboarding_tour_spec.rb
+++ b/spec/features/onboarding/backogs_onboarding_tour_spec.rb
@@ -29,6 +29,7 @@
 require 'spec_helper'
 
 describe 'backlogs onboarding tour', js: true do
+  let(:next_button) { find('.enjoyhint_next_btn') }
   let(:user) { FactoryBot.create :admin }
   let(:project) { FactoryBot.create :project, name: 'My Project', identifier: 'project1', is_public: true, enabled_module_names: %w[work_package_tracking backlogs] }
   let(:sprint) { FactoryBot.create(:version, project: project, name: 'Sprint 1') }
@@ -72,42 +73,41 @@ describe 'backlogs onboarding tour', js: true do
   context 'as a new user' do
     it 'I see a part of the onboarding tour in the backlogs section' do
       # Set the tour parameter so that we can start on the overview page
-      visit project_path(project.id)
-      page.execute_script("window.sessionStorage.setItem('openProject-onboardingTour', 'startOverviewTour');")
+      visit "/projects/#{project.identifier}/?start_onboarding_tour=true"
 
       expect(page).to have_text 'This is the project’s Overview page.'
 
-      find('.enjoyhint_next_btn').click
+      next_button.click
       expect(page).to have_text 'From the Project menu you can access all modules within a project.'
 
-      find('.enjoyhint_next_btn').click
+      next_button.click
       expect(page).to have_text 'In the Project settings you can configure your project’s modules.'
 
-      find('.enjoyhint_next_btn').click
+      next_button.click
       expect(page).to have_text 'Invite new Members to join your project.'
 
-      find('.enjoyhint_next_btn').click
+      next_button.click
       expect(page).to have_text 'Manage your work in the Backlogs view'
 
-      find('.backlogs-menu-item').click
+      next_button.click
       expect(page).to have_current_path backlogs_project_backlogs_path(project)
       expect(page).to have_text 'Here you can create epics, user stories and bugs'
 
-      find('.enjoyhint_next_btn').click
+      next_button.click
       expect(page).to have_text 'To open your Task board, click on the Sprint drop-down...'
 
-      find('.backlog .menu-trigger').click
+      next_button.click
       expect(page).to have_selector('.backlog .items', visible: true)
       expect(page).to have_text '... and select the Task board entry.'
 
-      find('.backlog .show_task_board').click
+      next_button.click
       backlogs_project_sprint_path(sprint.id, project.id)
       expect(page).to have_text 'The Task board visualizes the progress for each sprint.'
 
-      find('.enjoyhint_next_btn').click
+      next_button.click
       expect(page).to have_text 'Here is the Work package section'
 
-      find('#main-menu-work-packages-wrapper .toggler').click
+      next_button.click
       expect(page).to have_text  "Let's have a look at all open Work packages"
     end
   end

--- a/spec/features/onboarding/backogs_onboarding_tour_spec.rb
+++ b/spec/features/onboarding/backogs_onboarding_tour_spec.rb
@@ -1,0 +1,116 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe 'backlogs onboarding tour', js: true do
+  let(:user) { FactoryBot.create :admin }
+  let(:project) { FactoryBot.create :project, name: 'My Project', identifier: 'project1', is_public: true, enabled_module_names: %w[work_package_tracking backlogs] }
+  let(:sprint) { FactoryBot.create(:version, project: project, name: 'Sprint 1') }
+  let(:status) { FactoryBot.create(:default_status) }
+  let(:priority) { FactoryBot.create(:default_priority) }
+
+  let(:impediment) do
+    FactoryBot.build(:impediment, author: user,
+                     fixed_version: sprint,
+                     assigned_to: user,
+                     project: project,
+                     type: type_task,
+                     status: status)
+  end
+
+  let(:story_type) { FactoryBot.create(:type_feature) }
+  let(:task_type) do
+    type = FactoryBot.create(:type_task)
+    project.types << type
+
+    type
+  end
+
+  let!(:existing_story) do
+    FactoryBot.create(:work_package,
+                      type: story_type,
+                      project: project,
+                      status: status,
+                      priority: priority,
+                      position: 1,
+                      story_points: 3,
+                      fixed_version: sprint )
+  end
+
+  before do
+    login_as user
+    allow(Setting).to receive(:plugin_openproject_backlogs).and_return('story_types' => [story_type.id.to_s],
+                                                                       'task_type' => task_type.id.to_s)
+  end
+
+  context 'as a new user' do
+    it 'I see a part of the onboarding tour in the backlogs section' do
+      # Set the tour parameter so that we can start on the overview page
+      visit project_path(project.id)
+      page.execute_script("window.sessionStorage.setItem('openProject-onboardingTour', 'startOverviewTour');")
+
+      expect(page).to have_text 'This is the project’s Overview page.'
+
+      find('.enjoyhint_next_btn').click
+      expect(page).to have_text 'From the Project menu you can access all modules within a project.'
+
+      find('.enjoyhint_next_btn').click
+      expect(page).to have_text 'In the Project settings you can configure your project’s modules.'
+
+      find('.enjoyhint_next_btn').click
+      expect(page).to have_text 'Invite new Members to join your project.'
+
+      find('.enjoyhint_next_btn').click
+      expect(page).to have_text 'Manage your work in the Backlogs view'
+
+      find('.backlogs-menu-item').click
+      expect(page).to have_current_path backlogs_project_backlogs_path(project)
+      expect(page).to have_text 'Here you can create epics, user stories and bugs'
+
+      find('.enjoyhint_next_btn').click
+      expect(page).to have_text 'To open your Task board, click on the Sprint drop-down...'
+
+      find('.backlog .menu-trigger').click
+      expect(page).to have_selector('.backlog .items', visible: true)
+      expect(page).to have_text '... and select the Task board entry.'
+
+      find('.backlog .show_task_board').click
+      backlogs_project_sprint_path(sprint.id, project.id)
+      expect(page).to have_text 'The Task board visualizes the progress for each sprint.'
+
+      find('.enjoyhint_next_btn').click
+      expect(page).to have_text 'Here is the Work package section'
+
+      find('#main-menu-work-packages-wrapper .toggler').click
+      expect(page).to have_text  "Let's have a look at all open Work packages"
+    end
+  end
+end
+
+


### PR DESCRIPTION
This adds a class needed for the onboarding tour implemented in https://github.com/opf/openproject/pull/6743. Further a test case is added.